### PR TITLE
Fix icons merging, if font icon different from md or mdi

### DIFF
--- a/lib/index.vue
+++ b/lib/index.vue
@@ -78,7 +78,7 @@ export default {
         locale: 'en'
       }
       const fullOptions = Object.assign({}, defaultOptions, this.resolvedSchema['x-options'] || {}, this.options || {})
-      fullOptions.icons = Object.assign(icons, fullOptions.icons || {})
+      fullOptions.icons = Object.assign(icons || {}, fullOptions.icons || {})
       return fullOptions
     }
   }


### PR DESCRIPTION
Hi,

If vuetify use iconfont different from `md` or` mdi` (e.g. - `fa`), this library produce error:
```
TypeError: Cannot convert undefined or null to object
```