### PR TITLE
Add x-option to eager render tabs

### DIFF
--- a/lib/components/Property.vue
+++ b/lib/components/Property.vue
@@ -444,7 +444,7 @@
                   <v-tab v-for="(currentAllOf, i) in fullSchema.allOf" :key="i" :href="`#tab-${i}`">
                     {{ currentAllOf.title }}
                   </v-tab>
-                  <v-tab-item v-for="(currentAllOf, i) in fullSchema.allOf" :key="i" :value="`tab-${i}`">
+                  <v-tab-item v-for="(currentAllOf, i) in fullSchema.allOf" :key="i" :value="`tab-${i}`" :eager="options.eagerTabs">
                     <property
                       class="mt-2"
                       :schema="Object.assign({}, currentAllOf, {type: 'object', title: null})"

--- a/lib/index.vue
+++ b/lib/index.vue
@@ -50,6 +50,7 @@ export default {
         colors,
         autoFoldObjects: false,
         allOfTabs: false,
+        eagerTabs: false,
         requiredMessage: 'This information is required',
         noDataMessage: 'No matching value found',
         searchMessage: 'Search...',


### PR DESCRIPTION
By default, v-tabs are lazy loaded, which prevents the validation to
happen in tabs that weren't rendered yet.

If you want all validations to happen at the initial rendering of the
form, you must eager render all tabs.

This impacts the rendering performance and that's why it will continue
as lazy by default.