### PR TITLE
Add regular expression support as a validation rule

### DIFF
--- a/lib/VJsfNoDeps.js
+++ b/lib/VJsfNoDeps.js
@@ -75,6 +75,10 @@ export default {
         const msg = this.fullOptions.messages.minLength.replace('{minLength}', fullSchema.minLength.toLocaleString(this.fullOptions.locale))
         rules.push((val) => (val === undefined || val === null || val.length >= fullSchema.minLength) || msg)
       }
+       if (fullSchema.type === 'string' && fullSchema.regExp !== undefined) {
+        const msg = this.fullOptions.messages.regExp.replace('{regExp}', fullSchema.regExp.toLocaleString(this.fullOptions.locale))
+        rules.push((val) => (val === undefined || val === null || val.match(fullSchema.regExp) || msg)
+      }
       if (fullSchema.type === 'string' && fullSchema.maxLength !== undefined) {
         const msg = this.fullOptions.messages.maxLength.replace('{maxLength}', fullSchema.maxLength.toLocaleString(this.fullOptions.locale))
         rules.push((val) => (val === undefined || val === null || val.length <= fullSchema.maxLength) || msg)

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -29,7 +29,8 @@ export const localizedMessages = {
     minLength: '{minLength} characters minimum',
     maxLength: '{maxLength} characters maximum',
     minItems: 'No less than {minItems} items',
-    maxItems: 'No more than {maxItems} items'
+    maxItems: 'No more than {maxItems} items',
+    regExp: 'The text does not match the regular expression',
   },
   fr: {
     required: 'Cette information est obligatoire',
@@ -40,7 +41,8 @@ export const localizedMessages = {
     minLength: '{minLength} caractères minimum',
     maxLength: '{maxLength} caractères maximum',
     minItems: 'Au moins {minItems} éléments',
-    maxItems: 'Au plus {maxItems} éléments'
+    maxItems: 'Au plus {maxItems} éléments',
+    regExp: "Le texte ne correspond pas à l'expression régulière",
   },
   es: {
     required: 'Esta información es requerida',
@@ -51,7 +53,8 @@ export const localizedMessages = {
     minLength: '{minLength} caracteres mínimo',
     maxLength: '{maxLength} caractères máximo',
     minItems: 'Al menos {minItems} articulos',
-    maxItems: 'Hasta {maxItems} articulos'
+    maxItems: 'Hasta {maxItems} articulos',
+    regExp: 'El texto no coincide con la expresión regular',
   },
   de: {
     required: 'Diese Informationen sind erforderlich',
@@ -62,7 +65,8 @@ export const localizedMessages = {
     minLength: 'Mindestens {minLength} Zeichen',
     maxLength: 'Maximal {maxLength} Zeichen',
     minItems: 'Mindestens {minItems} Elemente',
-    maxItems: 'Bis zu {maxItems} Artikel'
+    maxItems: 'Bis zu {maxItems} Artikel',
+    regExp: 'Der Text stimmt nicht mit dem regulären Ausdruck überein',
   }
 }
 


### PR DESCRIPTION
The regular expression support could be used to validate email, urls, and so on, also can be jsonified easily.