### PR TITLE
Fix x-slot 'before' option

### DIFF
--- a/lib/VJsfNoDeps.js
+++ b/lib/VJsfNoDeps.js
@@ -137,7 +137,7 @@ export default {
     const children = []
     if (this.$scopedSlots.before) children.push(this.$scopedSlots.before(this.slotParams))
     else if (this.$slots.before) this.$slots.before.forEach(node => children.push(node))
-    else if (this.xSlots.before) children.push(h('template', { domProps: { innerHTML: this.fullOptions.markdown(this.xSlots.before) } }))
+    else if (this.xSlots.before) children.push(h('div', { domProps: { innerHTML: this.fullOptions.markdown(this.xSlots.before) } }))
 
     if (this.$scopedSlots.default) {
       children.push(this.$scopedSlots.default(this.slotParams))


### PR DESCRIPTION
Now you can use 'x-slot': { before:'some text'}  directly without ht need of using <template slot ...>
as in [code pen](https://codepen.io/Selobu/full/MWadLov)