### PR TITLE
Making it possible to let tooltips appear on hover via x-props.

### DIFF
--- a/lib/mixins/Tooltip.js
+++ b/lib/mixins/Tooltip.js
@@ -17,10 +17,11 @@ export default {
       if (this.fullOptions.hideTooltips) return
       return h('v-tooltip', {
         slot,
-        props: { value: this.tooltip.show, left: true, openOnHover: false, openOnClick: false, contentClass: 'vjsf-tooltip' },
+        props: { value: this.tooltip.show, left: true, openOnHover: false, openOnClick: false, contentClass: 'vjsf-tooltip', ...this.fullSchema['x-props'] },
         scopedSlots: {
-          activator: () => h('v-btn', {
-            on: { click: () => { this.tooltip.show = !this.tooltip.show } },
+          activator: ({ on, attrs }) => h('v-btn', {
+            on: on, // { click: () => { this.tooltip.show = !this.tooltip.show } },
+            attrs: attrs,
             props: { icon: true },
             style: 'pointer-events: auto' // necessary or the tooltip is disabled on readOnly props
           }, [h('v-icon', { }, this.fullOptions.icons.info)])


### PR DESCRIPTION
Use `'x-props': { openOnHover: true }` on your property to let the description appear on mouseover.