### PR TITLE
Add ability to use custom tags for components

### DIFF
--- a/doc/examples/slots.js
+++ b/doc/examples/slots.js
@@ -10,7 +10,10 @@ All slots are passed either as textual content in a \`x-slots\` annotation in th
 
 The markdown parser can be defined using the \`markdown\` option. If you use the default third party dependencies it will be [markdown-it](https://github.com/markdown-it/markdown-it) and it will be initialized with the \`markdownit\` option. For example you can use \`{markdownit: {html: true}}\` to accept HTML tags inside the markdown content.
 
-You can write code slots used for multiple properties by naming the slot with a \`custom-\` prefix and passing this name to the \`x-display\` annotation (see custom-string1 in this example).`
+You can write code slots used for multiple properties by naming the slot with a \`custom-\` prefix and passing this name to the \`x-display\` annotation (see custom-string1 in this example).
+
+For simple properties like \`boolean\`, \`number\` and \`string\` (and selectable lists) you can overwrite the tag used to render the property altogether by using the \`x-tag\`. This lets you use the tags that you defined in the application.
+`
 
 const schema = {
   type: 'object',
@@ -25,7 +28,8 @@ const schema = {
         stringProp11: { type: 'string', title: `I'm a nested property with slots`, 'x-slots': { 'append-outer': 'this is a markdown **slot**' } },
         stringProp12: { type: 'string', title: `I'm a nested property with a custom display`, 'x-display': 'custom-string1' }
       }
-    }
+    },
+    stringProp4: { type: 'boolean', title: `I'm a property with a custom tag`, 'x-tag': 'v-switch' }
   }
 }
 

--- a/lib/VJsfNoDeps.js
+++ b/lib/VJsfNoDeps.js
@@ -59,6 +59,7 @@ export default {
     fullKey() { return (this.parentKey + this.modelKey).replace('root.', '') },
     label() { return this.fullSchema.title || (typeof this.modelKey === 'string' ? this.modelKey : '') },
     display() { return this.modelKey === 'root' && this.fullOptions.rootDisplay ? this.fullOptions.rootDisplay : this.fullSchema['x-display'] },
+    customTag() { return this.fullSchema['x-tag'] },
     rules() {
       return getRules(this.fullSchema, this.fullOptions, this.required, this.isOneOfSelect)
     },

--- a/lib/mixins/SelectProperty.js
+++ b/lib/mixins/SelectProperty.js
@@ -295,6 +295,9 @@ export default {
           props.filter = (item, q) => (item[this.itemTitle] || item[this.itemKey]).toLowerCase().includes(q.toLowerCase())
         }
       }
+
+      tag = this.customTag ? this.customTag : tag
+
       return [h(tag, { props, on, scopedSlots }, children)]
     }
   }

--- a/lib/mixins/SimpleProperty.js
+++ b/lib/mixins/SimpleProperty.js
@@ -107,6 +107,8 @@ export default {
         children.push(this.renderTooltip(h, tooltipSlot))
       }
 
+      tag = this.customTag ? this.customTag : tag
+
       return tag ? [h(tag, { props, domProps, on, scopedSlots }, children)] : null
     }
   }


### PR DESCRIPTION
This change makes it easy to use a custom tag instead of a one predefined in the package.

Added also documentation adnotation in the slots section.