### PR TITLE
Fix NaN error for numbers validation

### DIFF
--- a/lib/mixins/SimpleProperty.js
+++ b/lib/mixins/SimpleProperty.js
@@ -51,7 +51,16 @@ export default {
         if (this.fullSchema.maximum !== undefined) props.max = this.fullSchema.maximum
         props.step = this.fullSchema['x-step'] || (this.fullSchema.type === 'integer' ? 1 : 0.01)
 
-        on.input = value => this.input(this.fullSchema.type === 'integer' ? parseInt(value, 10) : parseFloat(value))
+        on.input = value => {
+          if (!value) {
+            value = null
+          } else if (value === '-') {
+            value = '-'
+          } else {
+            value = (this.fullSchema.type === 'integer' ? parseInt(value, 10) : parseFloat(value)) | null
+          }
+          this.input(value)
+        }
       }
 
       if (this.fullSchema.type === 'boolean') {


### PR DESCRIPTION
Here https://github.com/koumoul-dev/vuetify-jsonschema-form/blob/master/lib/mixins/SimpleProperty.js#L54 we validate number input value with `parseInt` or `parseFloat`. In case of error in validation this function returns `NaN` value, so for example if we try to first enter some value and then clear it, we can see an error `The specified value "NaN" cannot be parsed, or is out of range.` in dev console. Also because of this error input value is not cleared, so we can see empty input with placeholder on top.
![image](https://user-images.githubusercontent.com/13859030/94851880-b74b3500-0431-11eb-8d3f-aa6d42484be2.png)
Also this validation leads to another error: if we don't have some default value in a provided model, when we try to enter `-` symbol (to enter some negative number) it won't be shown in input (and we can also see some errors in the console), to actually enter `-` we need to press it twice.

With this PR I suggest to set value `null` in case we have validation error, also to allow `-` in the input value. 

Here is a Codepen where you can see this problem
https://codepen.io/Sevenmonths/pen/VwaJyxK
