### PR TITLE
Verify that cookies are enabled before attempting to access localStorage

### DIFF
--- a/lib/VJsfNoDeps.js
+++ b/lib/VJsfNoDeps.js
@@ -17,7 +17,7 @@ import Tooltip from './mixins/Tooltip'
 import Validatable from './mixins/Validatable'
 import Dependent from './mixins/Dependent'
 
-const debugFlag = global.localStorage && global.localStorage.debug
+const debugFlag = navigator.cookieEnabled ? global.localStorage && global.localStorage.debug : null
 
 export default {
   name: 'VJsf',


### PR DESCRIPTION
This PR fixes the page crash that occurs when a user completely disables their cookies. It uses https://developer.mozilla.org/en-US/docs/Web/API/Navigator/cookieEnabled to check if cookies are enabled before accessing localStorage.

Closes #282.