### PR TITLE
Conditionalize prefilled arrays

### DIFF
--- a/doc/pages/configuration.vue
+++ b/doc/pages/configuration.vue
@@ -232,7 +232,8 @@ export default {
         idPrefix: 'a prefix applied to generated ids if you want to prevent potential conflicts',
         markdownit: 'options given to markdownit if you leave the markdown option to its default value',
         editMode: 'change the way editable arrays are rendered. Use "dialog" to edit items in separate dialogs, use "inline" to edit items in place.',
-        autofocus: 'attempt to give focus to the first simple field rendered.'
+        autofocus: 'attempt to give focus to the first simple field rendered.',
+        disablePrefilledArrays: 'ignores any prefilled arrays declared in the schema. May yield performance gains.'
       },
       locale: 'en',
       iconSets,

--- a/lib/mixins/EditableArray.js
+++ b/lib/mixins/EditableArray.js
@@ -96,7 +96,7 @@ export default {
     },
     renderArrayItemRO(h, item, i) {
       const modelKey = `item-${i}`
-      return h('v-jsf', {
+      const renderOptions = {
         props: {
           schema: this.readonlyItemSchema,
           value: item,
@@ -108,8 +108,10 @@ export default {
           separateValidation: false
         },
         ref: modelKey,
-        scopedSlots: this.childScopedSlots(this.fullSchema.key),
-        on: {
+        scopedSlots: this.childScopedSlots(this.fullSchema.key)
+      }
+      if (!this.options.disablePrefilledArrays) {
+        renderOptions.on = {
           input: (itemValue) => {
             // even if it readOnly we listen to changes in order to fill default values in prefilled arrays
             if (!this.editabledArrayProp.editedItems[i]) {
@@ -119,7 +121,8 @@ export default {
             }
           }
         }
-      }, this.childSlots(h, this.fullSchema.key))
+      }
+      return h('v-jsf', renderOptions, this.childSlots(h, this.fullSchema.key))
     },
     renderArrayItemEditButton(h, item, i, isCurrentInlineEdit) {
       const isNew = i === -1

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -50,7 +50,8 @@ export const defaultOptions = {
   arrayOperations: ['create', 'update', 'delete'],
   autofocus: false,
   httpOptions: {},
-  selectAll: false
+  selectAll: false,
+  disablePrefilledArrays: false
 }
 
 export const localizedMessages = {


### PR DESCRIPTION
This PR adds a new prop, `disablePrefilledArrays`, that disables prefilled arrays in vjsf.

We're using vjsf for https://github.com/dandi/dandiarchive and we've been running into performance issues with large array fields ([original issue for reference](https://github.com/koumoul-dev/vuetify-jsonschema-form/issues/257)). We did some profiling on vjsf and determined that removing [this code](https://github.com/koumoul-dev/vuetify-jsonschema-form/blob/master/lib/mixins/EditableArray.js#L112-L121) results in a significant performance boost. That code is related to loading "prefilled arrays", which our application does not make use of at the moment. Due to the significant performance overhead caused by this feature, we want to propose making it toggleable by a prop passed to vjsf (see the changes to the documentation for details).

Here are two examples of datasets that load slowly with vjsf 2.1.3. I've also included examples of those same datasets using a modified version of vjsf with the previously mentioned code removed. 


Dandiset 4 ([vjsf 2.1.3](https://codepen.io/mvandenburgh/pen/rNmragW), [forked vjsf with performance boost](https://codepen.io/mvandenburgh/pen/wvdxavL))

Dandiset 26 ([vjsf 2.1.3](https://codepen.io/mvandenburgh/pen/wvdxaaV), [forked vjsf with performance boost](https://codepen.io/mvandenburgh/pen/YzVjXPO))
