### PR TITLE
Allow auto-complete for object containers with subschemas

### DIFF
--- a/doc/examples/dynamic-content/select-subschemas.js
+++ b/doc/examples/dynamic-content/select-subschemas.js
@@ -4,7 +4,10 @@ const title = 'Selects of sub-schemas'
 
 const description = `An object containing a \`oneOf\` or \`anyOf\` with varying properties can be represented as a select used to switch between the sub-schemas.
 
-A \`const\` property is required to be used as unique key of a \`oneOf\` element.`
+A \`const\` property is required to be used as unique key of a \`oneOf\` element.
+
+You can change the select field to an auto-complete component with \`x-display = "autocomplete"\`.
+`
 
 const schema = {
   type: 'object',

--- a/lib/mixins/ObjectContainer.js
+++ b/lib/mixins/ObjectContainer.js
@@ -310,7 +310,17 @@ export default {
             this.triggerChangeCurrentOneOf = true
           }
         }
-        flatChildren.push(h('v-select', { props, on, style: (this.subSchemasConstProp && this.subSchemasConstProp['x-style']) || '' }, [this.renderTooltip(h, 'append-outer')]))
+        let tag = 'v-select'
+        if (this.customTag) tag = this.customTag
+        if (this.display === 'autocomplete') tag = 'v-autocomplete'
+
+        if (tag === 'v-autocomplete') {
+          props.noDataText = this.fullOptions.messages.noData
+          props.placeholder = this.fullOptions.messages.search
+          props.filter = (item, q) => (item[this.itemTitle] || item.properties[this.subSchemasConstProp.key].const).toLowerCase().includes(q.toLowerCase())
+        }
+
+        flatChildren.push(h(tag, { props, on, style: (this.subSchemasConstProp && this.subSchemasConstProp['x-style']) || '' }, [this.renderTooltip(h, 'append-outer')]))
         if (this.currentOneOf && this.showCurrentOneOf) {
           flatChildren.push(this.renderChildProp(h, { ...this.currentOneOf, type: 'object', title: null }, 'currentOneOf', this.sectionDepth + 1))
         }

--- a/lib/mixins/SelectProperty.js
+++ b/lib/mixins/SelectProperty.js
@@ -349,7 +349,6 @@ export default {
         loading: this.loading
       }
       if (tag === 'v-autocomplete') {
-        tag = 'v-autocomplete'
         props.noDataText = this.fullOptions.messages.noData
         props.placeholder = this.fullOptions.messages.search
         if (this.fromUrlWithQuery) {


### PR DESCRIPTION
Hi,

I made a small fix for https://github.com/koumoul-dev/vuetify-jsonschema-form/issues/361, which I opened some time ago. You recently made it possible to force the `autocomplete` tag in https://github.com/koumoul-dev/vuetify-jsonschema-form/commit/490f19f970ed0cf4f3726c8ed34c84db8e88933e and I would like to have this for conditional subschemas as well. The object container always picks a `v-select` [here](https://github.com/koumoul-dev/vuetify-jsonschema-form/blob/21d866b143454f0a1e6f975e63bfaeda991d5e25/lib/mixins/ObjectContainer.js#L313), however. This PR basically let's you pick an autocomplete with `x-display` in that class as well.

I also removed a redundant line in the select property.

Hope this works for you :)