### PR TITLE
Fix disabled and readonly props on v-form wrapper

### DIFF
--- a/lib/mixins/Validatable.js
+++ b/lib/mixins/Validatable.js
@@ -1,17 +1,20 @@
 // we bubble up and down validation instructions from the top form to the lower fields and through each container levels
 // each intermediate level is aware of its validation state wich is useful in sections management, complex array, etc.
 import { deepEqual } from 'fast-equals'
+import { computed } from 'vue'
 
 export default {
   inject: ['form'],
   provide() {
     return {
-      form: {
+      form: computed(() => ({
         register: this.register,
         unregister: this.unregister,
         fastForwardEvent: this.fastForwardEvent,
-        getExprNode: this.getExprNode
-      }
+        getExprNode: this.getExprNode,
+        disabled: this.form.disabled,
+        readonly: this.form.readonly
+      }))
     }
   },
   props: {


### PR DESCRIPTION
VForm api have disabled and readonly porps to control form inputs state.
![image](https://user-images.githubusercontent.com/79322668/208610496-8123a9bc-f8fb-4bde-bd8b-4e01fdd0967a.png)
Its work based on isDisabled and IsReadonly computed properties in inputs like VTextField, which is now set to undefined due to override "form" provided variable. I extend form object and make it computed property to bring back support of this features 