### PR TITLE
Add possibility to generate links from tooltips

### DIFF
--- a/doc/examples/dev/_link-descriptions.js
+++ b/doc/examples/dev/_link-descriptions.js
@@ -1,0 +1,34 @@
+const id = '_link-descriptions'
+
+const title = 'Descriptions can be direct links'
+
+const description = `Using the option "linkTooltipsIfAvailable" toolstips will be rendered as links opening in new tab if they are link-only.
+If not, they will be rendered as normal.`
+
+const schema = {
+  type: 'object',
+  properties: {
+    stringProp: { type: 'string', title: `I have a normal help message`, description: 'This is a normal help message.' },
+    booleanProp: { type: 'boolean', title: `I have a link only help message`, description: 'https://www.example.org' }
+  }
+}
+
+const model = {
+  stringProp: 'initial value',
+  booleanProp: true
+}
+
+const test = (wrapper) => {
+  const properties = wrapper.findAll('.vjsf-property')
+  expect(properties).toHaveLength(3)
+  expect(wrapper.findAll('.v-tooltip')).toHaveLength(1)
+  expect(wrapper.findAll('.v-btn')).toHaveLength(2)
+  expect(properties.at(1).find('.v-text-field')).toBeTruthy()
+  expect(wrapper.vm.valid).toBe(true)
+}
+
+const options = {
+  linkTooltipsIfAvailable: true
+}
+
+export default { id, title, description, schema, model, test, options }

--- a/doc/examples/dev/index.js
+++ b/doc/examples/dev/index.js
@@ -6,6 +6,7 @@ import readOnlySelectIcon from './_readonly-select-icon'
 import ValidationExtraCases from './_validation-extra-cases'
 import WrongTypes from './_wrong-types'
 import LargeForm from './_large-form'
+import LinkDescriptions from './_link-descriptions'
 import SimpleArrayValidation from './_simple-array-validation'
 import NestedAllofOneof from './_nested_allof_oneof'
 import PrefilledArrayWrongType from './_prefilled_array_wrong_type'
@@ -42,7 +43,8 @@ const examplesGroup = {
     ArrayRichExpression,
     ArrayOneOfTitle,
     ReadonlyOptions,
-    StringDefault
+    StringDefault,
+    LinkDescriptions
   ]
 }
 

--- a/doc/pages/configuration.vue
+++ b/doc/pages/configuration.vue
@@ -500,6 +500,7 @@ export default {
         hideReadOnly: 'by default read-only properties are rendered as disabled fields, set this to true to hide them entirely',
         deleteReadOnly: 'set this to true to not only hide read-only properties, but also remove them from the model',
         hideTooltips: 'by default descriptions are rendered as help tooltip on properties, set this to true to disable this functionality',
+        linkTooltipsIfAvailable: 'by default, link only descriptions will be rendered as regular tooltips, while this option renders links via opening them in a new tab',
         disableSorting: 'by default editable array are sortable, set this to true to disable this functionality',
         context: 'an optional contextual information object, properties from here can be used as variables in URL templates',
         rules: 'some custom rule functions that can be referenced by the x-rules annotation on properties',

--- a/lib/mixins/Tooltip.js
+++ b/lib/mixins/Tooltip.js
@@ -29,6 +29,9 @@ export default {
       if (this.fullOptions.linkTooltipsIfAvailable && this.isUrl) {
         return h('v-btn', {
           slot,
+          attrs: {
+            'aria-label': 'description'
+          },
           props: {
             icon: true,
             retainFocusOnClick: true,
@@ -51,7 +54,10 @@ export default {
             }
             return h('v-btn', {
               on,
-              attrs,
+              attrs: {
+                'aria-label': 'description',
+                ...attrs
+              },
               props: { icon: true, retainFocusOnClick: true },
               style: 'pointer-events: auto' // necessary or the tooltip is disabled on readOnly props
             }, [h('v-icon', { }, this.fullOptions.icons.info)])

--- a/lib/mixins/Tooltip.js
+++ b/lib/mixins/Tooltip.js
@@ -64,7 +64,7 @@ export default {
           }
         }
       }, [
-        h('div', { style: `max-width: ${this.tooltip.maxWidth}px`, domProps: { innerHTML: this.htmlDescription } })
+        h('div', { style: `max-width: ${this.tooltip.maxWidth}px`, domProps: { innerHTML: this.htmlDescription }, attrs: { 'aria-live': 'assertive' } })
       ])
     }
   }

--- a/lib/mixins/Tooltip.js
+++ b/lib/mixins/Tooltip.js
@@ -6,6 +6,17 @@ export default {
       }
     }
   },
+  computed: {
+    isUrl() {
+      let url
+      try {
+        url = new URL(this.fullSchema.description)
+      } catch (_) {
+        return false
+      }
+      return url.protocol === 'http:' || url.protocol === 'https:'
+    }
+  },
   mounted() {
     if (!this.htmlDescription) return
     if (this.$el && this.$el.getBoundingClientRect) this.tooltip.maxWidth = this.$el.getBoundingClientRect().left - 80
@@ -15,6 +26,18 @@ export default {
       if (this.fullOptions.hideTooltips) return
       if (this.fullOptions.hideReadOnlyTooltips && (this.fullSchema.readOnly || this.fullOptions.readOnlyArrayItem)) return
       if (!this.htmlDescription) return
+      if (this.fullOptions.linkTooltipsIfAvailable && this.isUrl) {
+        return h('v-btn', {
+          slot,
+          props: {
+            icon: true,
+            retainFocusOnClick: true,
+            href: this.fullSchema.description,
+            target: '_blank',
+            ...this.fullOptions.tooltipProps },
+          style: 'pointer-events: auto' // necessary or the tooltip is disabled on readOnly props
+        }, [h('v-icon', { }, this.fullOptions.icons.info)])
+      }
 
       return h('v-tooltip', {
         slot,

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -35,6 +35,7 @@ export const defaultOptions = {
   stepperProps: {},
   verticalStepperProps: {},
   tooltipProps: { left: true, openOnHover: false, openOnClick: true },
+  linkTooltipsIfAvailable: false,
   removeAdditionalProperties: true,
   disableAll: false,
   hideReadOnly: false,

--- a/test/__snapshots__/examples.spec.js.snap
+++ b/test/__snapshots__/examples.spec.js.snap
@@ -3660,6 +3660,160 @@ exports[`Examples used as simple test cases Default values 1`] = `
 </form>
 `;
 
+exports[`Examples used as simple test cases Descriptions can be direct links 1`] = `
+<form
+  class="v-form"
+  novalidate="novalidate"
+>
+  <div
+    class="col col-12 vjsf-property vjsf-property-root pa-0"
+  >
+    <div
+      class="row ma-0 "
+    >
+      <div
+        class="col col-12 vjsf-property vjsf-property-stringProp pa-0"
+      >
+        <div
+          class="v-input v-input--is-label-active v-input--is-dirty theme--light v-text-field v-text-field--is-booted"
+        >
+          <div
+            class="v-input__control"
+          >
+            <div
+              class="v-input__slot"
+            >
+              <div
+                class="v-text-field__slot"
+              >
+                <label
+                  class="v-label v-label--active theme--light"
+                  for="stringProp"
+                  style="left: 0px; position: absolute;"
+                >
+                  I have a normal help message
+                </label>
+                <input
+                  id="stringProp"
+                  type="text"
+                />
+              </div>
+            </div>
+            <div
+              class="v-text-field__details"
+            >
+              <div
+                class="v-messages theme--light"
+              >
+                <transition-group-stub
+                  class="v-messages__wrapper"
+                  name="message-transition"
+                  tag="div"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="v-input__append-outer"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
+              style="pointer-events: auto;"
+              type="button"
+            >
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-information theme--light"
+                />
+              </span>
+            </button>
+            <span
+              class="v-tooltip v-tooltip--left"
+            >
+              <!---->
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="col col-12 vjsf-property vjsf-property-booleanProp pa-0"
+      >
+        <div
+          class="v-input v-input--is-label-active v-input--is-dirty theme--light v-input--selection-controls v-input--checkbox primary--text"
+        >
+          <div
+            class="v-input__control"
+          >
+            <div
+              class="v-input__slot"
+            >
+              <div
+                class="v-input--selection-controls__input"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-checkbox-marked theme--light primary--text"
+                />
+                <input
+                  aria-checked="true"
+                  id="booleanProp"
+                  role="checkbox"
+                  type="checkbox"
+                  value="true"
+                />
+                <div
+                  class="v-input--selection-controls__ripple primary--text"
+                />
+              </div>
+              <label
+                class="v-label theme--light"
+                for="booleanProp"
+                style="left: 0px; position: relative;"
+              >
+                I have a link only help message
+              </label>
+            </div>
+            <div
+              class="v-messages theme--light primary--text"
+            >
+              <transition-group-stub
+                class="v-messages__wrapper"
+                name="message-transition"
+                tag="div"
+              />
+            </div>
+          </div>
+          <div
+            class="v-input__append-outer"
+          >
+            <a
+              class="v-btn v-btn--icon v-btn--left v-btn--round theme--light v-size--default"
+              href="https://www.example.org"
+              style="pointer-events: auto;"
+              target="_blank"
+            >
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-information theme--light"
+                />
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`Examples used as simple test cases Directives 1`] = `
 <form
   class="v-form"

--- a/test/__snapshots__/examples.spec.js.snap
+++ b/test/__snapshots__/examples.spec.js.snap
@@ -1171,6 +1171,7 @@ exports[`Examples used as simple test cases Basic types 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -1449,6 +1450,7 @@ exports[`Examples used as simple test cases Basic types 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -1532,6 +1534,7 @@ exports[`Examples used as simple test cases Basic types 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -2224,6 +2227,7 @@ exports[`Examples used as simple test cases Colors 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -3330,6 +3334,7 @@ exports[`Examples used as simple test cases Dates 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -3719,6 +3724,7 @@ exports[`Examples used as simple test cases Descriptions can be direct links 1`]
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -3792,6 +3798,7 @@ exports[`Examples used as simple test cases Descriptions can be direct links 1`]
             class="v-input__append-outer"
           >
             <a
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--left v-btn--round theme--light v-size--default"
               href="https://www.example.org"
               style="pointer-events: auto;"
@@ -10983,6 +10990,7 @@ exports[`Examples used as simple test cases Nested allOfs and oneOfs 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="true"
+            aria-label="description"
             class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
             style="pointer-events: auto;"
             type="button"
@@ -12022,6 +12030,7 @@ exports[`Examples used as simple test cases Read only content 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
+                  aria-label="description"
                   class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
                   style="pointer-events: auto;"
                   type="button"
@@ -15124,6 +15133,7 @@ exports[`Examples used as simple test cases Selection controls 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -15257,6 +15267,7 @@ exports[`Examples used as simple test cases Selection controls 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -15502,6 +15513,7 @@ exports[`Examples used as simple test cases Selects 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -15845,6 +15857,7 @@ exports[`Examples used as simple test cases Selects 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -16700,6 +16713,7 @@ exports[`Examples used as simple test cases Selects from HTTP 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -16813,6 +16827,7 @@ exports[`Examples used as simple test cases Selects of sub-schemas 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="true"
+            aria-label="description"
             class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
             style="pointer-events: auto;"
             type="button"
@@ -19157,6 +19172,7 @@ exports[`Examples used as simple test cases Vuetify props 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"
@@ -19298,6 +19314,7 @@ exports[`Examples used as simple test cases resolved schema 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
+              aria-label="description"
               class="v-btn v-btn--icon v-btn--round theme--light v-size--default"
               style="pointer-events: auto;"
               type="button"


### PR DESCRIPTION
Closes #383 

This PR adds a new option for tooltips `linkTooltipsIfAvailable` which, if true (default should be `false`) will render descriptions which contain just an URL not as tooltip but as directly clickable button which will open the link in a new window. If the the option is false, the old behaviour is preserved.

I also added a test/dev-example to the docs demonstrating the behaviour.

In addition, I added a second commit which adds an aria-label to the tooltip buttons. Currently, the buttons have no label at all which makes screen readers read them as "unlabelled button 1234" with some ID. This is a second commit, if you don't like it or would want me to provide a second PR, I can do so.

If you like my accessibility commit, I will likely supply a couple of further accessibility fixes in the future.