### PR TITLE
Replace deprecated slot and slot-scope with v-slot

### DIFF
--- a/doc/examples/advanced/slots-wrappers.js
+++ b/doc/examples/advanced/slots-wrappers.js
@@ -108,16 +108,16 @@ const model = {
 }
 
 const template = `<v-jsf v-model="model" :schema="schema" :options="options">
-  <template slot="custom-tiptap" slot-scope="context">
+  <template v-slot:custom-tiptap="context">
     <v-jsf-tiptap v-bind="context" />
   </template>
-  <template slot="custom-toast-ui-editor" slot-scope="context">
+  <template v-slot:custom-toast-ui-editor="context">
     <v-jsf-toast-ui-editor v-bind="context" />
   </template>
-  <template slot="custom-avatar" slot-scope="context">
+  <template v-slot:custom-avatar="context">
     <v-jsf-crop-img v-bind="context" />
   </template>
-  <template slot="custom-table" slot-scope="context">
+  <template v-slot:custom-table="context">
       <v-jsf-table v-bind="context" />
   </template>
 </v-jsf>`

--- a/doc/examples/advanced/slots.js
+++ b/doc/examples/advanced/slots.js
@@ -39,25 +39,25 @@ const schema = {
 const model = {}
 
 const template = `<v-jsf v-model="model" :schema="schema" :options="options">
-  <template slot="stringProp1-prepend">
+  <template v-slot:stringProp1-prepend>
     this is a Vuetify code slot
   </template>
-  <template slot="stringProp2-before" slot-scope="slotProps">
+  <template v-slot:stringProp2-before="slotProps">
     this is a code slot before 2nd property (slot props={{Object.keys(slotProps)}}).
   </template>
-  <template slot="stringProp2" slot-scope="{value, on}">
+  <template v-slot:stringProp2="{value, on}">
     <p class="mt-4">this is the default slot of the 2nd property <input type="text" :value="value" v-on="on" style="border:1px solid red;">.</p>
   </template>
-  <template slot="object1.stringProp11-before" slot-scope="slotProps">
+  <template v-slot:object1.stringProp11-before="slotProps">
     this is a code slot before nested property
   </template>
-  <template slot="allOf-0.stringProp21-before" slot-scope="slotProps">
+  <template v-slot:allOf-0.stringProp21-before="slotProps">
     this is a code slot before allOf property
   </template>
-  <template slot="allOf-0.stringProp21" slot-scope="{value, on}">
+  <template v-slot:allOf-0.stringProp21="{value, on}">
     <p class="mt-4">this is the default slot of the 2nd property <input type="text" :value="value" v-on="on" style="border:1px solid red;">.</p>
   </template>
-  <template slot="custom-string1" slot-scope="{value, label, on}"><p class="mt-4">
+  <template v-slot:custom-string1="{value, label, on}"><p class="mt-4">
     {{label}} <input type="text" :value="value" v-on="on" style="border:1px solid green;">.</p>
   </template>
 </v-jsf>`

--- a/doc/pages/editor.vue
+++ b/doc/pages/editor.vue
@@ -57,20 +57,17 @@
               :schema="schema"
             >
               <template
-                slot="custom-tiptap"
-                slot-scope="context"
+                v-slot:custom-tiptap="context"
               >
                 <v-jsf-tiptap v-bind="context" />
               </template>
               <template
-                slot="custom-toast-ui-editor"
-                slot-scope="context"
+                v-slot:custom-toast-ui-editor="context"
               >
                 <v-jsf-toast-ui-editor v-bind="context" />
               </template>
               <template
-                slot="custom-avatar"
-                slot-scope="context"
+                v-slot:custom-avatar="context"
               >
                 <v-jsf-crop-img v-bind="context" />
               </template>

--- a/test/utils.js
+++ b/test/utils.js
@@ -27,7 +27,7 @@ exports.getExampleWrapper = (example) => {
     .replace('"options"', '"props.options"')
     .replace(/logEvent/g, 'props.logEvent')
 
-  if (template.includes('slot-scope')) {
+  if (template.includes('v-slot:')) {
     // TODO: investigate
     console.log('No test for example with scoped slots')
     return


### PR DESCRIPTION
### What does this PR do?

* Change docs examples from using `slot` and `slot-scope` with `v-slot`-directive
* Adjusted identifier in `test/utils.js` 

I haven't used shorthand `#` as this might be confusing for people who don't know it. But I can change it if needed.

Closes #403 