### PR TITLE
Small feature: Add aria-heading role to sections

### DIFF
--- a/doc/pages/configuration.vue
+++ b/doc/pages/configuration.vue
@@ -511,7 +511,8 @@ export default {
         autoFixArrayItems: 'modify the items of arrays existing in the model (set default values, set const values, remove additional properties), you can try disabling this if you run into performance issues',
         useValidator: 'See the <a href="configuration#validator">JSON schema validator section</a>. Activate using the validator to display validation errors as a complement to the validation rules managed by vjsf directly.',
         evalMethod: 'See the <a href="configuration#expressions">Expressions section</a>. For security reasons this option can only be changed in the main options object given to vjsf, not in x-options annotations inside the schema.',
-        easyMDEOptions: 'See <a href="https://github.com/Ionaru/easy-markdown-editor">EasyMDE documentation</a>'
+        easyMDEOptions: 'See <a href="https://github.com/Ionaru/easy-markdown-editor">EasyMDE documentation</a>',
+        sectionHeadingAriaDepth: 'Set the accessibility heading level for sections. Nested sections will have an incremented heading level. Defaults to 3.'
       },
       locale: 'en',
       iconSets,

--- a/lib/mixins/ObjectContainer.js
+++ b/lib/mixins/ObjectContainer.js
@@ -317,7 +317,11 @@ export default {
       }
       return [h('v-row', { class: `ma-0 ${this.fullOptions.objectContainerClass}` }, [
         (this.showSectionTitle && h('v-col', { props: { cols: 12 }, class: 'pa-0' }, [h('span', {
-          class: 'py-2 ' + (this.fullOptions.sectionsTitlesClasses[this.sectionDepth - 1] || this.fullOptions.sectionsTitlesClasses[this.fullOptions.sectionsTitlesClasses.length - 1])
+          class: 'py-2 ' + (this.fullOptions.sectionsTitlesClasses[this.sectionDepth - 1] || this.fullOptions.sectionsTitlesClasses[this.fullOptions.sectionsTitlesClasses.length - 1]),
+          attrs: {
+            role: 'heading',
+            'aria-level': this.sectionDepth + this.fullOptions.sectionHeadingAriaDepth > 7 ? 7 : this.sectionDepth + this.fullOptions.sectionHeadingAriaDepth
+          }
         }, [`${this.fullSchema.title}\xa0`])])),
         // display a local error only we don't already have an error displayed in the children
         (this.localRuleError && !this.dedupChildrenWithValidatedErrors.length) && h('v-col', { props: { cols: 12 }, class: { 'px-0': true, 'error--text': true } }, this.localRuleError),

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -7,6 +7,7 @@ export const defaultOptions = {
   objectContainerClass: '',
   sectionsClass: 'pl-2 pt-2',
   sectionsTitlesClasses: ['title', 'subtitle-1', 'subtitle-2'],
+  sectionHeadingAriaDepth: 3,
   arrayItemsTitlesClasses: ['title', 'subtitle-1', 'subtitle-2'],
   childrenClass: '',
   fieldProps: {},

--- a/test/__snapshots__/examples.spec.js.snap
+++ b/test/__snapshots__/examples.spec.js.snap
@@ -3560,7 +3560,9 @@ exports[`Examples used as simple test cases Default values 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm a section with a default value 
             </span>
@@ -11827,7 +11829,9 @@ exports[`Examples used as simple test cases Read only content 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm a section with readOnly=true in schema 
             </span>
@@ -11901,7 +11905,9 @@ exports[`Examples used as simple test cases Read only content 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm a section with disableAll=true in options 
             </span>
@@ -11963,7 +11969,9 @@ exports[`Examples used as simple test cases Read only content 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm a section whose read-only content is hidden 
             </span>
@@ -12026,7 +12034,9 @@ exports[`Examples used as simple test cases Read only content 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm a section whose read-only content is deleted 
             </span>
@@ -13207,7 +13217,9 @@ exports[`Examples used as simple test cases Sections 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm a section 
             </span>
@@ -13273,7 +13285,9 @@ exports[`Examples used as simple test cases Sections 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm another section 
             </span>
@@ -13332,7 +13346,9 @@ exports[`Examples used as simple test cases Sections 1`] = `
                 class="col col-12 pa-0"
               >
                 <span
+                  aria-level="5"
                   class="py-2 subtitle-1"
+                  role="heading"
                 >
                   I'm a subsection 
                 </span>
@@ -13393,7 +13409,9 @@ exports[`Examples used as simple test cases Sections 1`] = `
                 class="col col-12 pa-0"
               >
                 <span
+                  aria-level="5"
                   class="py-2 subtitle-1"
+                  role="heading"
                 >
                   I'm another subsection 
                 </span>
@@ -13678,7 +13696,9 @@ exports[`Examples used as simple test cases Sections as stepper 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm an object with sections rendered in a stepper. 
             </span>
@@ -13908,7 +13928,9 @@ exports[`Examples used as simple test cases Sections as stepper 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm an object with sections rendered in a vertical stepper. 
             </span>
@@ -14408,7 +14430,9 @@ exports[`Examples used as simple test cases Sections validation 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               Tabs with required fields 
             </span>
@@ -14651,7 +14675,9 @@ exports[`Examples used as simple test cases Sections validation 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               Panels with required fields 
             </span>
@@ -18680,7 +18706,9 @@ exports[`Examples used as simple test cases Tuples 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm a tuple of 2 numbers 
             </span>
@@ -18785,7 +18813,9 @@ exports[`Examples used as simple test cases Tuples 1`] = `
             class="col col-12 pa-0"
           >
             <span
+              aria-level="4"
               class="py-2 title"
+              role="heading"
             >
               I'm a tuple of 2 strings, first one is required 
             </span>


### PR DESCRIPTION
Sections are meant to structure the vjsf form.

Therefore, in terms of accessibility, the section headers should represent "headings" with various nested levels.

This Commit adds corresponding aria attributes to the object container class, ensuring that headings are set accordingly, which allows easier navigation with screen readers (e.g. using the "h" button in JAWS to navigate sections"