### PR TITLE
fix: always accept empty string if string is non-required

### DIFF
--- a/lib/utils/rules.js
+++ b/lib/utils/rules.js
@@ -15,7 +15,7 @@ export const getRules = (schema, fullSchema, options, required, isOneOfSelect) =
   }
   if (fullSchema.type === 'string' && fullSchema.minLength !== undefined) {
     const msg = options.messages.minLength.replace('{minLength}', fullSchema.minLength.toLocaleString(options.locale))
-    rules.push((val) => (val === undefined || val === null || val.length >= fullSchema.minLength) || msg)
+    rules.push((val) => (val === undefined || val === null || (!required && val === '') || val.length >= fullSchema.minLength) || msg)
   }
   if (fullSchema.type === 'string' && fullSchema.maxLength !== undefined) {
     const msg = options.messages.maxLength.replace('{maxLength}', fullSchema.maxLength.toLocaleString(options.locale))


### PR DESCRIPTION
Modify a rule to allow a non-required string with a `minLength` >= 1 to be an empty string.

Closes #395 