### PR TITLE
Replace CommonJS with ES6 imports

### DIFF
--- a/lib/VJsfNoDeps.js
+++ b/lib/VJsfNoDeps.js
@@ -17,9 +17,10 @@ import Tooltip from './mixins/Tooltip'
 import Validatable from './mixins/Validatable'
 import Dependent from './mixins/Dependent'
 import exprEvalParser from './utils/expr-eval-parser'
-const expr = require('property-expr')
+import expr from 'property-expr'
+import debug from 'debug'
 
-const debugExpr = require('debug')('vjsf:expr')
+const debugExpr = debug('vjsf:expr')
 debugExpr.log = console.log.bind(console)
 
 const mountingIncs = {}

--- a/lib/deps/third-party.js
+++ b/lib/deps/third-party.js
@@ -3,9 +3,14 @@
 
 import Vue from 'vue'
 import Draggable from 'vuedraggable'
+import markdownIt from 'markdown-it'
+import ajv from 'ajv'
+import ajvI18n from 'ajv-i18n'
+import ajvFormats from 'ajv-formats'
+
 const _global = (typeof window !== 'undefined' && window) || (typeof global !== 'undefined' && global) || {}
-_global.markdownit = require('markdown-it')
+_global.markdownit = markdownIt
 Vue.component('Draggable', Draggable)
-_global.Ajv = require('ajv')
-_global.ajvLocalize = require('ajv-i18n')
-_global.ajvAddFormats = require('ajv-formats')
+_global.Ajv = ajv
+_global.ajvLocalize = ajvI18n
+_global.ajvAddFormats = ajvFormats

--- a/lib/mixins/SelectProperty.js
+++ b/lib/mixins/SelectProperty.js
@@ -1,7 +1,7 @@
 import { deepEqual } from 'fast-equals'
 import selectUtils from '../utils/select'
-const matchAll = require('match-all')
-const debounce = require('debounce-promise')
+import matchAll from 'match-all'
+import debounce from 'debounce-promise'
 
 export default {
   data() {

--- a/lib/utils/json-refs.js
+++ b/lib/utils/json-refs.js
@@ -1,7 +1,7 @@
 // Inspired by this without the fs references :
 // https://github.com/coderofsalvation/json-ref-lite/blob/master/index.js
 
-var expr = require('property-expr')
+import expr from 'property-expr'
 
 const jrefs = {}
 jrefs.cache = {}


### PR DESCRIPTION
Thank you for your work on this library. I am trying to use it in a Vue 2 project which uses Vite and has been configured to use ES6 modules via `"type": "module"` in `package.json` . Unfortunately this kind of setup is currently not working with vuetify-jsonschema-form as the source code within the repository mixes CommonJS and ES6 imports.

With a regular Vue CLI based toolchain this works just fine as Babel will end up transforming all of them into one format, but with a Vite-based stack and no Babel the usage of this library is sadly not possible.

Would it be possible to have these changes merged and released as a minor version? I am currently running a fork to have vjsf working, but it would be wonderful to rely on upstream again. The changes themselves should be fairly minor and simply replace the few occurrences of CommonJS imports with proper ES6 module imports - like most of the library already are.