### PR TITLE
fix: handle null array in `initFromSchema()`

### DIFF
--- a/lib/VJsfNoDeps.js
+++ b/lib/VJsfNoDeps.js
@@ -511,7 +511,7 @@ export default {
       this.initSelectProp(value)
       this.initObjectContainer(value)
       // Cleanup arrays of empty items
-      if (this.fullSchema.type === 'array') {
+      if (this.value && this.fullSchema.type === 'array') {
         value = this.value.filter(item => ![undefined, null].includes(item))
       }
 


### PR DESCRIPTION
Fixes #427

The `initFromSchema()` method assumes that an object with a `type` of `"array"` is always non-null and can be iterated over with `Array.prototype.filter()`. However, a nullable array is perfectly valid in a JSON Schema.

I _think_ that's a correct summary of what's going wrong here, but I'm not familiar enough with the codebase to say for sure.