### PR TITLE
Add codespell config and workflow (to detect new typos) + fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,*.svg,package-lock.json,*.css,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,7 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git,*.svg,package-lock.json,*.css,.codespellrc
+skip = .git,*.svg,package-lock.json,*.css,.codespellrc,options.js
 check-hidden = true
-# ignore-regex = 
+# Ignore lines which have non-english characters
+ignore-regex = .*[éà].*
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -26,7 +26,7 @@ This simply opens the documentation site in a local web server that will watch y
 
 Please note that you can open a single example in a lighter page by replacing the # by a slash in the URL (for example http://localhost:3133/examples#basic => http://localhost:3133/examples/basic).
 
-An additionnal "Development" group of examples is visible, please add in this group examples that do not need to be presented to the users but has some value for maintainers.
+An additional "Development" group of examples is visible, please add in this group examples that do not need to be presented to the users but has some value for maintainers.
 
 ## Tests
 
@@ -40,11 +40,11 @@ To increase efficiency test cases and documented examples are the same thing in 
 
 When running tests each example is rendered and a HTML snapshot is extracted and compared to a previous one. When the tests fail because of a snapshot diff, you should check that it is a valid change, then run `npm run test-update`.
 
-You can also write additionnal test assertions in the examples themselves, see [_resolved-schema.js](./doc/examples/_resolved-schema.js) for example.
+You can also write additional test assertions in the examples themselves, see [_resolved-schema.js](./doc/examples/_resolved-schema.js) for example.
 
 ## Publishing
 
-Release and publish usin npm:
+Release and publish using npm:
 
 ```
 npm version minor

--- a/doc/components/wrappers/v-jsf-table.vue
+++ b/doc/components/wrappers/v-jsf-table.vue
@@ -99,9 +99,9 @@
  *
  * @param obj - The input object
  * @param path - The value path definition e.g.: "prop1.prop2"
- * @param separater - The property separator in path definition
+ * @param separator - The property separator in path definition
  *
- * @returns Tha value defined path in obj or undefined
+ * @returns The value defined path in obj or undefined
  */
 function getObjectValue (obj, path, separator = '.') {
   if (path.startsWith(separator)) {

--- a/doc/examples/dev/_calculated-value.js
+++ b/doc/examples/dev/_calculated-value.js
@@ -16,7 +16,7 @@ const schema = {
       type: 'string',
       readOnly: true,
       'x-options': { evalMethod: 'evalExpr' },
-      'x-constExpr': 'concatString("Hello ", toUpperCase(parent.value.string1), " !")'
+      'x-constExpr': 'concatString("Hello ", toUpperCase(data.string1), " !")'
     }
   }
 }

--- a/doc/examples/dev/_calculated-value.js
+++ b/doc/examples/dev/_calculated-value.js
@@ -1,0 +1,28 @@
+const id = '_calculated-value'
+
+const title = 'Calculate the value of a property'
+
+const description = ``
+
+const schema = {
+  type: 'object',
+  properties: {
+    string1: {
+      title: `I'm a string whose value is used to calculate the next property`,
+      type: 'string'
+    },
+    string2: {
+      title: `I'm a string whose value is calculated`,
+      type: 'string',
+      readOnly: true,
+      'x-options': { evalMethod: 'evalExpr' },
+      'x-constExpr': '"Hello " || parent.value.string1 || " !"'
+    }
+  }
+}
+
+const model = {
+  string1: 'world'
+}
+
+export default { id, title, description, schema, model }

--- a/doc/examples/dev/_calculated-value.js
+++ b/doc/examples/dev/_calculated-value.js
@@ -16,7 +16,7 @@ const schema = {
       type: 'string',
       readOnly: true,
       'x-options': { evalMethod: 'evalExpr' },
-      'x-constExpr': '"Hello " || parent.value.string1 || " !"'
+      'x-constExpr': 'concatString("Hello ", toUpperCase(parent.value.string1), " !")'
     }
   }
 }

--- a/doc/examples/dev/index.js
+++ b/doc/examples/dev/index.js
@@ -18,6 +18,7 @@ import ArrayRichExpression from './_array_rich_expression'
 import ArrayOneOfTitle from './_array_oneof_title'
 import ReadonlyOptions from './_readonly-options'
 import StringDefault from './_string_default'
+import CalculatedValue from './_calculated-value'
 
 const examplesGroup = {
   title: 'Development',
@@ -42,7 +43,8 @@ const examplesGroup = {
     ArrayRichExpression,
     ArrayOneOfTitle,
     ReadonlyOptions,
-    StringDefault
+    StringDefault,
+    CalculatedValue
   ]
 }
 

--- a/doc/examples/single-properties/date-picker.js
+++ b/doc/examples/single-properties/date-picker.js
@@ -4,7 +4,7 @@ const title = 'Dates'
 
 const description = `The formats relative to dates are managed using the date and time pickers from Vuetify.
 
-The formatting and the pickers are heavily dependant on the \`locale\` option. To customize the formatting you can look at the \`Formatting functions\` section in the configuration documentation.
+The formatting and the pickers are heavily dependent on the \`locale\` option. To customize the formatting you can look at the \`Formatting functions\` section in the configuration documentation.
 
 You can define props for the underlying components using the timePickerProps and datePickerProps options.
 

--- a/doc/pages/about.vue
+++ b/doc/pages/about.vue
@@ -32,7 +32,7 @@
         <li><b>completeness</b> - the main JSON schemas semantics should be covered as well as the most common use-cases for forms in Web applications</li>
         <li><b>extensibility</b> - more specific use cases should also be supported through the use of lower level tools like slots, classes, etc.</li>
         <li><b>validity</b> - the output of the form should be valid against the provided schema</li>
-        <li><b>homogeneity</b> - the look and feel should be consistent accross all form functionalities and inside your application as a whole</li>
+        <li><b>homogeneity</b> - the look and feel should be consistent across all form functionalities and inside your application as a whole</li>
       </ul>
     </p>
     <p>

--- a/doc/pages/examples/index.vue
+++ b/doc/pages/examples/index.vue
@@ -27,7 +27,7 @@ export default {
     }
   },
   mounted () {
-    // depcrecated now that we use SSR
+    // deprecated now that we use SSR
     if (this.$route.hash && process.client) {
       location.hash = this.$route.hash
       scrollToHash(this.$route.hash, false)

--- a/doc/pages/getting-started.vue
+++ b/doc/pages/getting-started.vue
@@ -59,7 +59,7 @@ Vue.component('VJsf', VJsf)</code></pre>
       Import module from source
     </h3>
     <p>
-      This is useful if you wish to let your build tool analyze the source code of vjsf. Particularily interesting if you use vuetify-loader.
+      This is useful if you wish to let your build tool analyze the source code of vjsf. Particularly interesting if you use vuetify-loader.
     </p>
     <v-sheet
 v-hljs

--- a/lib/VJsf.css
+++ b/lib/VJsf.css
@@ -61,3 +61,7 @@
   border-bottom-color: transparent !important;
   border-left-color: transparent !important;
 }
+
+.vjsf-array-item .v-alert__content {
+  max-width: 100%;
+}

--- a/lib/VJsfNoDeps.js
+++ b/lib/VJsfNoDeps.js
@@ -336,12 +336,15 @@ export default {
       return this._vjsf_cache[key].value
     },
     // used by all functionalities that require looking into the data or the context (x-if, fromData, etc)
-    getFromExpr(exp) {
+    getFromExpr(exp, parentValueData = false) {
       const expData = this.getExprNode()
       expData.modelRoot = this.modelRoot
       expData.root = this.modelRoot
       expData.model = this.value
       expData.context = this.options.context
+      if (parentValueData) {
+        expData.data = expData.parent && expData.parent.value
+      }
 
       this._vjsf_getters = this._vjsf_getters || {}
 
@@ -514,7 +517,7 @@ export default {
 
       // Case of a select based on an array somewhere in the data
       if (this.fullSchema['x-constExpr']) {
-        this.$watch(() => this.getFromExpr(this.fullSchema['x-constExpr']), (val) => {
+        this.$watch(() => this.getFromExpr(this.fullSchema['x-constExpr'], true), (val) => {
           this.input(val, true)
         }, { immediate: true })
       } else {

--- a/lib/VJsfNoDeps.js
+++ b/lib/VJsfNoDeps.js
@@ -511,7 +511,15 @@ export default {
       if (this.fullSchema.type === 'array') {
         value = this.value.filter(item => ![undefined, null].includes(item))
       }
-      return this.input(this.fixProperties(value), true)
+
+      // Case of a select based on an array somewhere in the data
+      if (this.fullSchema['x-constExpr']) {
+        this.$watch(() => this.getFromExpr(this.fullSchema['x-constExpr']), (val) => {
+          this.input(val, true)
+        }, { immediate: true })
+      } else {
+        return this.input(this.fixProperties(value), true)
+      }
     }
   }
 }

--- a/lib/VJsfNoDeps.js
+++ b/lib/VJsfNoDeps.js
@@ -17,9 +17,10 @@ import Tooltip from './mixins/Tooltip'
 import Validatable from './mixins/Validatable'
 import Dependent from './mixins/Dependent'
 import exprEvalParser from './utils/expr-eval-parser'
-const expr = require('property-expr')
+import expr from 'property-expr'
+import debug from 'debug'
 
-const debugExpr = require('debug')('vjsf:expr')
+const debugExpr = debug('vjsf:expr')
 debugExpr.log = console.log.bind(console)
 
 const mountingIncs = {}

--- a/lib/deps/third-party.js
+++ b/lib/deps/third-party.js
@@ -3,9 +3,14 @@
 
 import Vue from 'vue'
 import Draggable from 'vuedraggable'
+import markdownIt from 'markdown-it'
+import ajv from 'ajv'
+import ajvI18n from 'ajv-i18n'
+import ajvFormats from 'ajv-formats'
+
 const _global = (typeof window !== 'undefined' && window) || (typeof global !== 'undefined' && global) || {}
-_global.markdownit = require('markdown-it')
+_global.markdownit = markdownIt
 Vue.component('Draggable', Draggable)
-_global.Ajv = require('ajv')
-_global.ajvLocalize = require('ajv-i18n')
-_global.ajvAddFormats = require('ajv-formats')
+_global.Ajv = ajv
+_global.ajvLocalize = ajvI18n
+_global.ajvAddFormats = ajvFormats

--- a/lib/deps/third-party.js
+++ b/lib/deps/third-party.js
@@ -1,4 +1,4 @@
-// import this module if you want to be sure that you get all dependancies
+// import this module if you want to be sure that you get all dependencies
 // used by vjsf functionalities (color picker, etc.)
 
 import Vue from 'vue'

--- a/lib/mixins/DateProperty.js
+++ b/lib/mixins/DateProperty.js
@@ -5,7 +5,7 @@ const padTimeComponent = (val) => {
 }
 
 // storing ISO times with the user's timezone offset is more dense in information that always storing the base ISO date
-// this way the application can either use the localized time or the ISO time by chosing to interpret or not the offset part
+// this way the application can either use the localized time or the ISO time by choosing to interpret or not the offset part
 // cf https://usefulangle.com/post/30/javascript-get-date-time-with-offset-hours-minutes
 // 2020-04-03T19:07:43.152Z => 2020-04-03T21:07:43+02:00
 const getDateTimeWithOffset = (date) => {

--- a/lib/mixins/SelectProperty.js
+++ b/lib/mixins/SelectProperty.js
@@ -1,7 +1,7 @@
 import { deepEqual } from 'fast-equals'
 import selectUtils from '../utils/select'
-const matchAll = require('match-all')
-const debounce = require('debounce-promise')
+import matchAll from 'match-all'
+import debounce from 'debounce-promise'
 
 export default {
   data() {

--- a/lib/mixins/SimpleProperty.js
+++ b/lib/mixins/SimpleProperty.js
@@ -23,6 +23,7 @@ export default {
       const props = { ...this.commonFieldProps }
 
       const domProps = {}
+      const attrs = {}
       const children = [...this.renderPropSlots(h)]
       const on = {
         input: value => this.input(value),
@@ -42,7 +43,7 @@ export default {
           Object.assign(props, this.fullOptions.textFieldProps)
           if (this.display === 'password') {
             props.type = 'password'
-            props.autocomplete = props.autocomplete || 'off'
+            attrs.autocomplete = 'new-password'
           }
         }
         if (this.fullOptions.maxLengthCounter && this.fullSchema.maxLength) props.counter = this.fullSchema.maxLength
@@ -158,7 +159,7 @@ export default {
 
       tag = this.customTag ? this.customTag : tag
 
-      return tag ? [h(tag, { props, domProps, on, scopedSlots, directives: this.directives }, children)] : null
+      return tag ? [h(tag, { props, domProps, attrs, on, scopedSlots, directives: this.directives }, children)] : null
     }
   }
 }

--- a/lib/mixins/Validatable.js
+++ b/lib/mixins/Validatable.js
@@ -1,5 +1,5 @@
 // we bubble up and down validation instructions from the top form to the lower fields and through each container levels
-// each intermediate level is aware of its validation state wich is useful in sections management, complex array, etc.
+// each intermediate level is aware of its validation state which is useful in sections management, complex array, etc.
 import { deepEqual } from 'fast-equals'
 
 export default {

--- a/lib/utils/expr-eval-parser.js
+++ b/lib/utils/expr-eval-parser.js
@@ -9,10 +9,10 @@ const parser = new Parser({
   factorial: true,
   multiply: true,
   power: true,
-  remainer: true,
-  substract: true,
+  remainder: true,
+  subtract: true,
 
-  //  programatic, allowed so that function definition is possible
+  //  programmatic, allowed so that function definition is possible
   assignment: true,
 
   //  logical

--- a/lib/utils/expr-eval-parser.js
+++ b/lib/utils/expr-eval-parser.js
@@ -1,16 +1,17 @@
 import { Parser } from 'expr-eval'
 
-export default new Parser({
+const parser = new Parser({
   //  Useless in our use case
   //  mathematical
-  add: false,
-  concatenate: false,
-  divide: false,
-  factorial: false,
-  multiply: false,
-  power: false,
-  remainer: false,
-  substract: false,
+  add: true,
+  concatenate: true,
+  divide: true,
+  factorial: true,
+  multiply: true,
+  power: true,
+  remainer: true,
+  substract: true,
+
   //  programatic, allowed so that function definition is possible
   assignment: true,
 
@@ -19,3 +20,28 @@ export default new Parser({
   comparison: true,
   in: true
 })
+
+parser.functions.concatString = function () {
+  let result = ''
+  for (let i = 0; i < arguments.length; i++) {
+    result += arguments[i]
+  }
+  return result
+}
+
+parser.functions.toUpperCase = function (arg) {
+  if (typeof arg !== 'string') return arg
+  return arg.toUpperCase()
+}
+
+parser.functions.toLowerCase = function (arg) {
+  if (typeof arg !== 'string') return arg
+  return arg.toLowerCase()
+}
+
+parser.functions.trim = function (arg) {
+  if (typeof arg !== 'string') return arg
+  return arg.trim()
+}
+
+export default parser

--- a/lib/utils/json-refs.js
+++ b/lib/utils/json-refs.js
@@ -1,7 +1,7 @@
 // Inspired by this without the fs references :
 // https://github.com/coderofsalvation/json-ref-lite/blob/master/index.js
 
-var expr = require('property-expr')
+import expr from 'property-expr'
 
 const jrefs = {}
 jrefs.cache = {}

--- a/lib/utils/rules.js
+++ b/lib/utils/rules.js
@@ -15,7 +15,7 @@ export const getRules = (schema, fullSchema, options, required, isOneOfSelect) =
   }
   if (fullSchema.type === 'string' && fullSchema.minLength !== undefined) {
     const msg = options.messages.minLength.replace('{minLength}', fullSchema.minLength.toLocaleString(options.locale))
-    rules.push((val) => (val === undefined || val === null || val.length >= fullSchema.minLength) || msg)
+    rules.push((val) => (val === undefined || val === null || (!required && val === '') || val.length >= fullSchema.minLength) || msg)
   }
   if (fullSchema.type === 'string' && fullSchema.maxLength !== undefined) {
     const msg = options.messages.maxLength.replace('{maxLength}', fullSchema.maxLength.toLocaleString(options.locale))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koumoul/vjsf",
-      "version": "2.21.3",
+      "version": "2.21.4",
       "license": "MIT",
       "dependencies": {
         "debounce": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koumoul/vjsf",
-      "version": "2.21.2",
+      "version": "2.21.3",
       "license": "MIT",
       "dependencies": {
         "debounce": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koumoul/vjsf",
-      "version": "2.23.1",
+      "version": "2.23.2",
       "license": "MIT",
       "dependencies": {
         "debounce": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koumoul/vjsf",
-      "version": "2.23.0",
+      "version": "2.23.1",
       "license": "MIT",
       "dependencies": {
         "debounce": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.21.4",
+  "version": "2.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koumoul/vjsf",
-      "version": "2.21.4",
+      "version": "2.22.0",
       "license": "MIT",
       "dependencies": {
         "debounce": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koumoul/vjsf",
-      "version": "2.22.1",
+      "version": "2.23.0",
       "license": "MIT",
       "dependencies": {
         "debounce": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koumoul/vjsf",
-      "version": "2.22.0",
+      "version": "2.22.1",
       "license": "MIT",
       "dependencies": {
         "debounce": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "Generate forms for the vuetify UI library (vuejs) based on annotated JSON schemas.",
   "main": "dist/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test-update": "jest --updateSnapshot",
     "doc-build": "(cd doc && TARGET=https://koumoul-dev.github.io/vuetify-jsonschema-form/latest/ nuxt generate)",
     "doc-master": "(cd doc && TARGET=https://koumoul-dev.github.io/vuetify-jsonschema-form/master/ nuxt generate) && gh-pages-multi deploy -v -s doc/dist -t master",
+    "doc-2x": "(cd doc && TARGET=https://koumoul-dev.github.io/vuetify-jsonschema-form/2.x/ nuxt generate) && gh-pages-multi deploy -v -s doc/dist -t 2.x",
     "analyze": "webpack --profile --json > dist/stats.json && webpack-bundle-analyzer dist/stats.json"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "description": "Generate forms for the vuetify UI library (vuejs) based on annotated JSON schemas.",
   "main": "dist/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "description": "Generate forms for the vuetify UI library (vuejs) based on annotated JSON schemas.",
   "main": "dist/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "description": "Generate forms for the vuetify UI library (vuejs) based on annotated JSON schemas.",
   "main": "dist/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "Generate forms for the vuetify UI library (vuejs) based on annotated JSON schemas.",
   "main": "dist/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "Generate forms for the vuetify UI library (vuejs) based on annotated JSON schemas.",
   "main": "dist/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koumoul/vjsf",
-  "version": "2.21.4",
+  "version": "2.22.0",
   "description": "Generate forms for the vuetify UI library (vuejs) based on annotated JSON schemas.",
   "main": "dist/main.js",
   "scripts": {

--- a/test/__snapshots__/examples.spec.js.snap
+++ b/test/__snapshots__/examples.spec.js.snap
@@ -2168,6 +2168,98 @@ exports[`Examples used as simple test cases Basic validation 1`] = `
 </form>
 `;
 
+exports[`Examples used as simple test cases Calculate the value of a property 1`] = `
+<form
+  class="v-form"
+  novalidate="novalidate"
+>
+  <div
+    class="col col-12 vjsf-property vjsf-property-root pa-0"
+  >
+    <div
+      class="row ma-0 "
+    >
+      <div
+        class="col col-12 vjsf-property vjsf-property-string1 pa-0"
+      >
+        <div
+          class="v-input v-input--is-label-active v-input--is-dirty theme--light v-text-field v-text-field--is-booted"
+        >
+          <div
+            class="v-input__control"
+          >
+            <div
+              class="v-input__slot"
+            >
+              <div
+                class="v-text-field__slot"
+              >
+                <label
+                  class="v-label v-label--active theme--light"
+                  for="string1"
+                  style="left: 0px; position: absolute;"
+                >
+                  I'm a string whose value is used to calculate the next property
+                </label>
+                <input
+                  id="string1"
+                  type="text"
+                />
+              </div>
+            </div>
+            <div
+              class="v-text-field__details"
+            >
+              <div
+                class="v-messages theme--light"
+              >
+                <transition-group-stub
+                  class="v-messages__wrapper"
+                  name="message-transition"
+                  tag="div"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="col col-12 vjsf-property vjsf-property-string2 pa-0 read-only"
+      >
+        <div
+          class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty v-input--is-disabled theme--light v-text-field v-text-field--is-booted"
+        >
+          <div
+            class="v-input__control"
+          >
+            <div
+              class="v-input__slot"
+            >
+              <div
+                class="v-text-field__slot"
+              >
+                <label
+                  class="v-label v-label--active v-label--is-disabled theme--light"
+                  for="string2"
+                  style="left: 0px; position: absolute;"
+                >
+                  I'm a string whose value is calculated
+                </label>
+                <input
+                  disabled="disabled"
+                  id="string2"
+                  type="text"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`Examples used as simple test cases Colors 1`] = `
 <form
   class="v-form"


### PR DESCRIPTION
A token of gratitude (or a bribe to facilitate review #428 ;) ): add https://github.com/codespell-project/codespell support and get some typos fixed.

TODOs:
- [ ] decide if fixes to `lib/utils/expr-eval-parser.js` are ok since seems to fix there... looking at https://github.com/silentmatt/expr-eval/blob/HEAD/parser.d.ts#L22 (if I got the target interface right) -- seems to be correct fixes