### PR TITLE
Give form a unique id and fix `itemErrorMessages is undefined` error

### DIFF
--- a/lib/src/composables/use-vjsf.js
+++ b/lib/src/composables/use-vjsf.js
@@ -49,7 +49,7 @@ export const useVjsf = (schema, modelValue, options, nodeComponents, emit, compi
       id: `vjsf-${Math.random().toString(36).substring(2, 9)}`,
       validate: () => {
         statefulLayout.value?.validate()
-        return statefulLayout.value?.errors
+        return statefulLayout.value?.errors || []
       },
       reset: () => statefulLayout.value?.resetValidation(), // TODO: also empty the data ?
       resetValidation: () => statefulLayout.value?.resetValidation(),

--- a/lib/src/composables/use-vjsf.js
+++ b/lib/src/composables/use-vjsf.js
@@ -46,7 +46,7 @@ export const useVjsf = (schema, modelValue, options, nodeComponents, emit, compi
   const form = inject(Symbol.for('vuetify:form'), null)
   if (form) {
     form.register({
-      id: 'vjsf', // TODO: a unique random id ?
+      id: `vjsf-${Math.random().toString(36).substring(2, 9)}`,
       validate: () => {
         statefulLayout.value?.validate()
         return statefulLayout.value?.errors


### PR DESCRIPTION
This PR fixes one warning and one error that I encountered several times when using VJSF:

`Uncaught (in promise) TypeError: itemErrorMessages is undefined`
-> `form.validate()` sometimes returns undefined instead of a list which causes this error

`[Vue warn]: Vuetify: Duplicate input name "vjsf"`
-> Everytime two vjsf forms are on one page