### PR TITLE
Use v-img and v-avatar for select icon image

### DIFF
--- a/lib/src/components/fragments/select-item-icon.vue
+++ b/lib/src/components/fragments/select-item-icon.vue
@@ -3,6 +3,7 @@
 
 import { defineComponent, h, computed } from 'vue'
 import { VIcon } from 'vuetify/components/VIcon'
+import { VAvatar, VImg } from "vuetify/components";
 
 export default defineComponent({
   props: {
@@ -16,7 +17,9 @@ export default defineComponent({
     const isSVG = computed(() => props.icon.startsWith('<?xml') || props.icon.startsWith('<svg'))
     return () => {
       if (isUrl.value) {
-        return h('img', { src: props.icon, style: 'height:100%;width:100%;' })
+        return h(VAvatar, {size: 'x-small', 'rounded': false}, [
+          h(VImg, { src: props.icon, cover: true }),
+        ]);
       } else if (isSVG.value) {
         return h('div', { innerHTML: props.icon.replace('<svg ', '<svg class="v-icon__svg" '), class: 'v-icon' })
       } else {


### PR DESCRIPTION
Currently, when an icon within a select property is an URL, an `<img>` tag with style `width: 100%, height: 100%` is used.
However, this displays the mentioned image in its original size instead of normalizing the icon size.

This PR makes it use the v-avatar and v-img component instead, so that the image/icon has a fixed size.