### PR TITLE
Restore support for custom array components with x-display in v2compat schema transformation

### DIFF
--- a/lib/src/compat/v2.js
+++ b/lib/src/compat/v2.js
@@ -165,7 +165,7 @@ const processFragment = (schema, getJSONRef, schemaId, processed) => {
 
     if (schema.type === 'array' && schema.items) {
       if (!Array.isArray(schema.items)) {
-        layout.comp = 'list'
+        layout.comp = layout.comp ?? 'list'
         if (schema['x-itemTitle']) layout.itemTitle = `data["${schema['x-itemTitle']}"]`
         else {
           // vjsf 2 implicitly used a title property as an item title in lists

--- a/lib/test/compat.test.ts
+++ b/lib/test/compat.test.ts
@@ -29,6 +29,39 @@ describe('schema compatibility function', () => {
     assert.ok(compileLayout(schema))
   })
 
+  it('should transform array with x-display to custom layout component', () => {
+    const inputSchema = {
+      type: 'object',
+      properties: {
+        customComponent: {
+          type: 'array',
+          'x-display': 'custom-component',
+          items: {
+            type: 'object',
+            properties: {
+              column_1: { type: 'string', title: 'Column 1' },
+              column_2: { type: 'array', title: 'Column 2' },
+            }
+          }
+        },
+        defaultList: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              column_1: { type: 'string', title: 'Column 1' },
+              column_2: { type: 'array', title: 'Column 2' },
+            }
+          }
+        },
+      }
+    }
+
+    const schema = v2compat(inputSchema)
+    assert.equal(schema.properties.customComponent.layout, 'custom-component')
+    assert.equal(schema.properties.defaultList.layout, 'list')
+  })
+
   it('should transform a expression with number indexing', () => {
     const schema = v2compat({
       type: 'object',


### PR DESCRIPTION
This pull request restores support for custom array components using the x-display property in the v2compat schema transformation. The changes ensure backward compatibility and transformation of schemas with custom array components.

Closes #489.