### PR TITLE
fix(pickers): close on outside click

### DIFF
--- a/lib/src/components/fragments/text-field-menu.vue
+++ b/lib/src/components/fragments/text-field-menu.vue
@@ -24,7 +24,17 @@ const props = defineProps({
     /** @type import('vue').PropType<string | null> */
     type: String,
     default: null
-  }
+  },
+  minWidth: {
+    /** @type import('vue').PropType<string> */
+    type: String,
+    default: '328px',
+  },
+  maxWidth: {
+    /** @type import('vue').PropType<string> */
+    type: String,
+    default: '328px',
+  },
 })
 
 const emits = defineEmits(['blur'])
@@ -47,6 +57,8 @@ const fieldProps = computed(() => {
 const menuProps = computed(() => {
   return {
     ...compProps.value,
+    minWidth: props.minWidth,
+    maxWidth: props.maxWidth,
     zIndex: 3000, // vuetify zIndex stacking is buggy (for example https://github.com/vuetifyjs/vuetify/issues/16251)
     closeOnContentClick: false,
     disabled: true

--- a/lib/src/components/nodes/color-picker.vue
+++ b/lib/src/components/nodes/color-picker.vue
@@ -27,11 +27,19 @@ const colorPickerProps = computed(() => {
   colorPickerProps.modelValue = localData.value
   return colorPickerProps
 })
+
+const menuProps = computed(() => {
+  return {
+    minWidth: '300px',
+    maxWidth: '300px',
+  }
+})
 </script>
 
 <template>
   <text-field-menu
     :model-value="modelValue"
+    v-bind="menuProps"
     :stateful-layout="statefulLayout"
     :formatted-value="modelValue.data"
   >

--- a/lib/src/components/nodes/date-time-picker.vue
+++ b/lib/src/components/nodes/date-time-picker.vue
@@ -78,7 +78,7 @@ const timePickerProps = computed(() => {
     <template #prepend-inner>
       <v-icon :icon="statefulLayout.options.icons.calendar" />
     </template>
-    <v-sheet style="width: 328px">
+    <v-sheet>
       <v-tabs
         v-model="tab"
         align-tabs="center"

--- a/lib/src/components/nodes/time-picker.vue
+++ b/lib/src/components/nodes/time-picker.vue
@@ -47,7 +47,7 @@ const timePickerProps = computed(() => {
     <template #prepend-inner>
       <v-icon :icon="statefulLayout.options.icons.clock" />
     </template>
-    <v-sheet style="width: 328px">
+    <v-sheet>
       <v-defaults-provider :defaults="{global: { density: 'default' }}">
         <v-time-picker
           v-bind="timePickerProps"


### PR DESCRIPTION
Fixes the issue where dateTime/time/color pickers wouldn't close when clicking outside the component. Now they close when clicking anywhere outside the component.


### Before:
<img width="623" height="623" alt="before" src="https://github.com/user-attachments/assets/ad1c31d9-d40e-4ffd-89fe-8ca601e5f79f" />

### After:
<img width="649" height="620" alt="after" src="https://github.com/user-attachments/assets/c73a5dc7-2c9a-4f16-8a2a-9f43d191e604" />

Fixes #496 