### PR TITLE
Enable scrollbar for readonly textareas (#509)

### DIFF
--- a/lib/src/components/nodes/textarea.vue
+++ b/lib/src/components/nodes/textarea.vue
@@ -54,4 +54,8 @@ export default defineComponent({
   overflow: hidden;
   mask-image: linear-gradient(180deg, #000 66%, transparent 90%);
 }
+
+.vjsf-readonly textarea {
+  pointer-events: auto;
+}
 </style>


### PR DESCRIPTION
This PR updates the textarea component to display a scrollbar in readonly mode.

 
<img width="883" height="201" alt="textarea" src="https://github.com/user-attachments/assets/7f218eaa-4765-4672-8325-5efcd32b08c1" />

```json
{
  "type": "object",
  "properties": {
    "description": {
      "type": "string",
      "title": "A simple string property",
      "layout" : {
        "comp" :  "textarea",
        "readOnly": true
      }
    }
  }
}
```
