### PR TITLE
fix(markdown): flush pending input on unmount

### DIFF
--- a/plugins/markdown/src/editor.vue
+++ b/plugins/markdown/src/editor.vue
@@ -1,5 +1,5 @@
 <script>
-import { defineComponent, h, computed, onMounted, ref, onUnmounted, watch } from 'vue'
+import { defineComponent, h, computed, onMounted, onBeforeUnmount, ref, onUnmounted, watch } from 'vue'
 import { useDefaults, useTheme } from 'vuetify'
 import { VInput, VLabel } from 'vuetify/components'
 import { marked } from 'marked'
@@ -92,6 +92,8 @@ export default defineComponent({
 
     /** @type {EasyMDE | null} */
     let easymde = null
+
+    let changed = false
 
     const initEasyMDE = async () => {
       if (props.readOnly) return
@@ -242,7 +244,7 @@ export default defineComponent({
       // @ts-ignore
       easymde = new EasyMDE(config)
 
-      let changed = false
+      changed = false
       easymde.codemirror.on('change', () => {
         changed = true
         if (easymde) emit('update:modelValue', easymde.value())
@@ -264,6 +266,21 @@ export default defineComponent({
     }
 
     onMounted(initEasyMDE)
+
+    // flush pending changes synchronously before unmount: if the component is torn down
+    // while the 500ms blur timeout is still pending (e.g. user closes the dialog right
+    // after typing), emit('blur') would never reach the parent and updateOn='blur' setups
+    // would drop the input.
+    onBeforeUnmount(() => {
+      if (blurTimeout) {
+        clearTimeout(blurTimeout)
+        blurTimeout = null
+      }
+      if (changed) {
+        emit('blur')
+        changed = false
+      }
+    })
 
     onUnmounted(() => {
       if (easymde) easymde.toTextArea()


### PR DESCRIPTION
## Summary

The CodeMirror `blur` handler in the markdown editor wraps `emit('blur')` in a 500 ms `setTimeout` to absorb toolbar-button blur/refocus cycles. If the component is torn down before that timeout fires — e.g. the consumer closes a `<v-dialog>` immediately after typing — the parent never receives the blur event.

Setups that configure VJSF with `updateOn: 'blur'` (common for editor dialogs) then drop the last input silently, because `@json-layout/core` holds the pending data behind `_dataWaitingForBlur` and only releases it on `statefulLayout.blur()`.

## Fix

Add an `onBeforeUnmount` hook that:
- clears the pending 500 ms blur timeout,
- emits `blur` synchronously if a change is still pending (`changed` moved to component-scope so the hook can read it).

This makes the plugin safe to use inside dialogs / routes that unmount quickly after input.

## Test plan

- [x] Reproduced on `@data-fair/portals` page editor: text block → type → close dialog → **no PATCH** (before fix)
- [x] Same scenario after fix → single PATCH sent on dialog close
- [x] Regular flow (blur → click outside) still emits exactly one blur, no double-save