### PR TITLE
feat: enable xI18n by default in the online editor

### DIFF
--- a/doc/pages/editor.vue
+++ b/doc/pages/editor.vue
@@ -159,17 +159,29 @@ const options = ref(null)
 const data = ref(null)
 const theme = ref('light')
 
+// options that the editor writes into the options tab when they are missing,
+// so that their value is always visible and editable instead of being an
+// invisible default diverging from the library's own defaults
+/** @param {any} editorOptions */
+const withEditorOptions = (editorOptions) => {
+  // the persisted options can be anything the user typed in the options tab
+  if (!editorOptions || typeof editorOptions !== 'object' || Array.isArray(editorOptions)) return editorOptions
+  // xI18n is opt-in in the library, but the editor pre-fills it so that
+  // x-i18n-* annotations can be tried out without retyping the option
+  return { ...editorOptions, xI18n: editorOptions.xI18n ?? true }
+}
+
 onMounted(() => {
   const editorStateStr = window.localStorage.getItem('vjsf-editor-state')
   if (editorStateStr) {
     const editorState = JSON.parse(editorStateStr)
     schema.value = editorState.schema
-    options.value = editorState.options ?? {}
+    options.value = withEditorOptions(editorState.options ?? {})
     data.value = editorState.data ?? {}
   }
   else {
     schema.value = firstExample.schema
-    options.value = firstExample.options ?? {}
+    options.value = withEditorOptions({ ...firstExample.options })
     data.value = firstExample.data ?? {}
   }
   watchDebounced([schema, options, data], () => {
@@ -194,16 +206,12 @@ const height = computed(() => windowHeight.value - 56)
 const validationErrors = ref({})
 /** @type import('vue').Ref<any | null> */
 const vjsfParams = ref(null)
-// xI18n is opt-in in the library, but we enable it by default in the online editor
-// for convenience (it can still be disabled with `xI18n: false` in the options)
-const editorDefaultOptions = { xI18n: true }
 watch([schema, options], () => {
   if (!options.value || !schema.value) return
   let compiledLayout
   try {
     compiledLayout = compile(schema.value, {
       ...defaultOptions,
-      ...editorDefaultOptions,
       ...options.value,
       components: { [VjsfMarkdown.info.name]: VjsfMarkdown.info },
     })
@@ -214,7 +222,7 @@ watch([schema, options], () => {
   }
 
   if (!Object.keys(validationErrors.value).length) {
-    vjsfParams.value = { options: { ...editorDefaultOptions, ...options.value, plugins: [VjsfMarkdown] }, schema: schema.value }
+    vjsfParams.value = { options: { ...options.value, plugins: [VjsfMarkdown] }, schema: schema.value }
   }
 }, { immediate: true })
 

--- a/doc/pages/editor.vue
+++ b/doc/pages/editor.vue
@@ -194,12 +194,16 @@ const height = computed(() => windowHeight.value - 56)
 const validationErrors = ref({})
 /** @type import('vue').Ref<any | null> */
 const vjsfParams = ref(null)
+// xI18n is opt-in in the library, but we enable it by default in the online editor
+// for convenience (it can still be disabled with `xI18n: false` in the options)
+const editorDefaultOptions = { xI18n: true }
 watch([schema, options], () => {
   if (!options.value || !schema.value) return
   let compiledLayout
   try {
     compiledLayout = compile(schema.value, {
       ...defaultOptions,
+      ...editorDefaultOptions,
       ...options.value,
       components: { [VjsfMarkdown.info.name]: VjsfMarkdown.info },
     })
@@ -210,7 +214,7 @@ watch([schema, options], () => {
   }
 
   if (!Object.keys(validationErrors.value).length) {
-    vjsfParams.value = { options: { ...options.value, plugins: [VjsfMarkdown] }, schema: schema.value }
+    vjsfParams.value = { options: { ...editorDefaultOptions, ...options.value, plugins: [VjsfMarkdown] }, schema: schema.value }
   }
 }, { immediate: true })
 


### PR DESCRIPTION
Enable the `xI18n` option by default in the online editor (`doc/pages/editor.vue`) via a local `editorDefaultOptions = { xI18n: true }`, applied to both the `compile()` call and the rendered `vjsf` params, ahead of the user-supplied options so it stays overridable with `xI18n: false`.

**Why:** when testing schemas with `x-i18n-*` annotations in the editor, `xI18n: true` had to be re-added to the options every time, which was tedious.

**Regression risks:**
- Editor-only: the library's exported `defaultOptions` is untouched, so `@koumoul/vjsf` consumers are unaffected.
- Within the editor, schemas using `x-i18n-*` are now resolved by default; to test the unresolved behaviour you must set `xI18n: false` explicitly.
