### PR TITLE
perf: avoid re-rendering the whole form on every interaction

### DIFF
--- a/lib/src/components/node-content.vue
+++ b/lib/src/components/node-content.vue
@@ -54,7 +54,7 @@ if (props.statefulLayout._renderCounts) {
 // or by whatever wrapped this part of the form), only nodes that actually change the
 // density need to provide it, a disabled v-defaults-provider skips the costly
 // per-node mergeDeep of the vuetify defaults chain
-const vuetifyDefaults = inject(Symbol.for('vuetify:defaults'), undefined)
+const vuetifyDefaults = /** @type {import('vue').Ref<import('vuetify').DefaultsInstance> | undefined} */ (inject(Symbol.for('vuetify:defaults'), undefined))
 const setsDensity = computed(() => {
   const density = props.modelValue.options.density
   return density !== undefined && vuetifyDefaults?.value?.global?.density !== density

--- a/lib/src/components/node-content.vue
+++ b/lib/src/components/node-content.vue
@@ -1,6 +1,6 @@
 <script setup>
 import Debug from 'debug'
-import { computed, onRenderTriggered, onUpdated } from 'vue'
+import { computed, inject, onRenderTriggered, onUpdated } from 'vue'
 import { useTheme, useDefaults } from 'vuetify'
 import { VCol } from 'vuetify/components/VGrid'
 import { VDefaultsProvider } from 'vuetify/components/VDefaultsProvider'
@@ -50,6 +50,15 @@ if (props.statefulLayout._renderCounts) {
   })
 }
 
+// almost all nodes share the density already provided above them (by the root node
+// or by whatever wrapped this part of the form), only nodes that actually change the
+// density need to provide it, a disabled v-defaults-provider skips the costly
+// per-node mergeDeep of the vuetify defaults chain
+const vuetifyDefaults = inject(Symbol.for('vuetify:defaults'), undefined)
+const setsDensity = computed(() => {
+  const density = props.modelValue.options.density
+  return density !== undefined && vuetifyDefaults?.value?.global?.density !== density
+})
 const densityDefaults = computed(() => ({ global: { density: props.modelValue.options.density } }))
 
 const indent = computed(() => {
@@ -84,7 +93,10 @@ if (props.modelValue.layout.comp !== 'none' && !props.modelValue.slots?.componen
 </script>
 
 <template>
-  <v-defaults-provider :defaults="densityDefaults">
+  <v-defaults-provider
+    :defaults="densityDefaults"
+    :disabled="!setsDensity"
+  >
     <v-col
       v-if="modelValue.layout.comp !== 'none'"
       :cols="modelValue.cols"

--- a/lib/src/composables/use-vjsf.js
+++ b/lib/src/composables/use-vjsf.js
@@ -2,7 +2,8 @@ import { useDefaults, useLocale } from 'vuetify'
 import { StatefulLayout } from '@json-layout/core/state'
 import { inject, provide, toRaw, shallowRef, computed, ref, watch, useSlots, getCurrentInstance, nextTick } from 'vue'
 import { useElementSize } from '@vueuse/core'
-import { getFullOptions, sameOptions } from '../options.js'
+import { getFullOptions } from '../options.js'
+import equal from 'fast-deep-equal'
 import { createClipboard } from './use-clipboard.js'
 import { setAutoFreeze } from 'immer'
 import Debug from 'debug'
@@ -184,7 +185,8 @@ export const useVjsf = (schema, modelValue, options, nodeComponents, emit, compi
       // a re-render of the parent can produce a new but equivalent options object,
       // replacing the stateful layout options in that case would rebuild the whole
       // state tree, break the identity of every node and re-render the whole form
-      if (oldOptions && sameOptions(toRaw(newOptions), toRaw(oldOptions))) {
+      // (fast-deep-equal compares functions by reference, which is what we want here)
+      if (oldOptions && equal(toRaw(newOptions), toRaw(oldOptions))) {
         debug('  -> equivalent options, ignore')
         return
       }

--- a/lib/src/composables/use-vjsf.js
+++ b/lib/src/composables/use-vjsf.js
@@ -2,7 +2,7 @@ import { useDefaults, useLocale } from 'vuetify'
 import { StatefulLayout } from '@json-layout/core/state'
 import { inject, provide, toRaw, shallowRef, computed, ref, watch, useSlots, getCurrentInstance, nextTick } from 'vue'
 import { useElementSize } from '@vueuse/core'
-import { getFullOptions } from '../options.js'
+import { getFullOptions, sameOptions } from '../options.js'
 import { createClipboard } from './use-clipboard.js'
 import { setAutoFreeze } from 'immer'
 import Debug from 'debug'
@@ -178,9 +178,16 @@ export const useVjsf = (schema, modelValue, options, nodeComponents, emit, compi
   }
 
   // case where options are updated from outside
-  watch(fullOptions, (newOptions) => {
+  watch(fullOptions, (newOptions, oldOptions) => {
     debug('watch fullOptions', fullOptions)
     if (statefulLayout.value) {
+      // a re-render of the parent can produce a new but equivalent options object,
+      // replacing the stateful layout options in that case would rebuild the whole
+      // state tree, break the identity of every node and re-render the whole form
+      if (oldOptions && sameOptions(toRaw(newOptions), toRaw(oldOptions))) {
+        debug('  -> equivalent options, ignore')
+        return
+      }
       debug('  -> update statefulLayout options')
       statefulLayout.value.options = toRaw(newOptions)
     } else {

--- a/lib/src/options.js
+++ b/lib/src/options.js
@@ -73,25 +73,3 @@ export const getFullOptions = (options, form, width, locale, globalDefaults, slo
   }
   return fullOptions
 }
-
-/**
- * Compare two full options objects. Functions and any previously seen references are
- * compared by reference, plain data deeply. Used to skip stateful layout updates when
- * a re-render produced a new but equivalent options object, as replacing the options
- * needlessly rebuilds the whole state tree and re-renders every node.
- * @param {any} a
- * @param {any} b
- * @returns {boolean}
- */
-export const sameOptions = (a, b) => {
-  if (a === b) return true
-  if (typeof a === 'function' || typeof b === 'function') return false
-  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') return false
-  if (Array.isArray(a) !== Array.isArray(b)) return false
-  const aKeys = Object.keys(a)
-  if (aKeys.length !== Object.keys(b).length) return false
-  for (const key of aKeys) {
-    if (!(key in b) || !sameOptions(a[key], b[key])) return false
-  }
-  return true
-}

--- a/lib/src/options.js
+++ b/lib/src/options.js
@@ -64,10 +64,34 @@ export const getFullOptions = (options, form, width, locale, globalDefaults, slo
     onAutofocus,
     context: options?.context ? JSON.parse(JSON.stringify(options.context)) : {},
     width: Math.round(width ?? 0),
-    vjsfSlots: { ...slots },
+    // the slots object returned by useSlots() is stable and mutated in place by vue,
+    // keep its identity so that an equivalent options recompute stays equivalent
+    vjsfSlots: slots,
     components,
     nodeComponents,
     icons
   }
   return fullOptions
+}
+
+/**
+ * Compare two full options objects. Functions and any previously seen references are
+ * compared by reference, plain data deeply. Used to skip stateful layout updates when
+ * a re-render produced a new but equivalent options object, as replacing the options
+ * needlessly rebuilds the whole state tree and re-renders every node.
+ * @param {any} a
+ * @param {any} b
+ * @returns {boolean}
+ */
+export const sameOptions = (a, b) => {
+  if (a === b) return true
+  if (typeof a === 'function' || typeof b === 'function') return false
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') return false
+  if (Array.isArray(a) !== Array.isArray(b)) return false
+  const aKeys = Object.keys(a)
+  if (aKeys.length !== Object.keys(b).length) return false
+  for (const key of aKeys) {
+    if (!(key in b) || !sameOptions(a[key], b[key])) return false
+  }
+  return true
 }

--- a/lib/test/density-defaults.test.js
+++ b/lib/test/density-defaults.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick, shallowRef } from 'vue'
+import { createVuetify } from 'vuetify'
+import { VDefaultsProvider } from 'vuetify/components/VDefaultsProvider'
+import { compile, StatefulLayout } from '@json-layout/core'
+import Tree from '../src/components/tree.vue'
+import { nodeComponents } from '../src/components/nodes/index.js'
+import { defaultIcons } from '../src/options.js'
+
+const vuetify = createVuetify()
+
+async function mountForm (schema, initialData = {}) {
+  const compiledLayout = compile(schema)
+  const statefulLayout = new StatefulLayout(
+    compiledLayout,
+    compiledLayout.skeletonTrees[compiledLayout.mainTree],
+    {
+      debounceInputMs: 0,
+      width: 1000,
+      density: 'comfortable',
+      nodeComponents,
+      icons: defaultIcons,
+      onData: () => {},
+      onUpdate: () => {},
+      onAutofocus: () => {}
+    },
+    initialData
+  )
+  const stateTree = shallowRef(statefulLayout.stateTree)
+  const wrapper = mount(Tree, {
+    props: { modelValue: stateTree.value, statefulLayout },
+    global: { plugins: [vuetify] }
+  })
+  await nextTick()
+  await nextTick()
+  return wrapper
+}
+
+// count the defaults providers that actually provide something, a disabled provider
+// does not chain a mergeDeep of the vuetify defaults
+const activeProviders = (wrapper) => wrapper.findAllComponents(VDefaultsProvider).filter(c => !c.props().disabled)
+
+describe('density defaults providers', () => {
+  it('should only provide the density once when all nodes share the form density', async () => {
+    const wrapper = await mountForm({
+      type: 'object',
+      properties: {
+        str1: { type: 'string' },
+        str2: { type: 'string' },
+        obj1: {
+          type: 'object',
+          properties: { str3: { type: 'string' } }
+        }
+      }
+    })
+    expect(wrapper.findAll('.vjsf-node').length).toBeGreaterThan(3)
+    expect(activeProviders(wrapper).length).toBe(1)
+    // the form density is applied to the fields
+    expect(wrapper.find('.vjsf-node-text-field .v-input--density-comfortable').exists()).toBe(true)
+  })
+
+  it('should provide the density again on nodes that override it', async () => {
+    const wrapper = await mountForm({
+      type: 'object',
+      properties: {
+        str1: { type: 'string' },
+        obj1: {
+          type: 'object',
+          layout: { options: { density: 'compact' } },
+          properties: { str2: { type: 'string' } }
+        }
+      }
+    })
+    expect(activeProviders(wrapper).length).toBe(2)
+    // the override applies to the section content, the sibling keeps the form density
+    expect(wrapper.find('.vjsf-node-section .v-input--density-compact').exists()).toBe(true)
+    expect(wrapper.find('.v-input--density-comfortable').exists()).toBe(true)
+  })
+})

--- a/lib/test/options-identity.test.js
+++ b/lib/test/options-identity.test.js
@@ -22,7 +22,7 @@ vi.mock('@vueuse/core', async (importOriginal) => {
 const { mount } = await import('@vue/test-utils')
 const { createVuetify } = await import('vuetify')
 const { default: Vjsf } = await import('../src/components/vjsf.vue')
-const { sameOptions } = await import('../src/options.js')
+const { default: equal } = await import('fast-deep-equal')
 
 const vuetify = createVuetify()
 
@@ -59,13 +59,11 @@ describe('options object identity', () => {
     expect(statefulLayout.stateTree.root.options.density).toBe('compact')
   })
 
-  it('should compare functions by reference and plain data deeply in sameOptions', () => {
+  // the options comparison relies on fast-deep-equal comparing functions by reference
+  // (same reference equal, different references not equal) and plain data deeply
+  it('should compare functions by reference and plain data deeply', () => {
     const fn = () => {}
-    expect(sameOptions({ a: 1, b: { c: [1, 2] }, fn }, { a: 1, b: { c: [1, 2] }, fn })).toBe(true)
-    expect(sameOptions({ a: 1 }, { a: 2 })).toBe(false)
-    expect(sameOptions({ fn }, { fn: () => {} })).toBe(false)
-    expect(sameOptions({ a: { b: 1 } }, { a: { b: 1, c: 2 } })).toBe(false)
-    expect(sameOptions({ a: [1, 2] }, { a: [1, 2] })).toBe(true)
-    expect(sameOptions({ a: [1, 2] }, { a: { 0: 1, 1: 2 } })).toBe(false)
+    expect(equal({ a: 1, b: { c: [1, 2] }, fn }, { a: 1, b: { c: [1, 2] }, fn })).toBe(true)
+    expect(equal({ fn }, { fn: () => {} })).toBe(false)
   })
 })

--- a/lib/test/options-identity.test.js
+++ b/lib/test/options-identity.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+// happy-dom has no real layout, so useElementSize() reports a 0 width forever and
+// vjsf never initializes its StatefulLayout (see use-vjsf.js initStatefulLayout).
+// Emulate a real browser by reporting 0 on the first render then a real width on the
+// next tick, which is what triggers the StatefulLayout init.
+vi.mock('@vueuse/core', async (importOriginal) => {
+  /** @type any */
+  const actual = await importOriginal()
+  const { ref: vref, nextTick: vnextTick } = await import('vue')
+  return {
+    ...actual,
+    useElementSize: () => {
+      const width = vref(0)
+      vnextTick(() => { width.value = 1000 })
+      return { width, height: vref(0) }
+    }
+  }
+})
+
+const { mount } = await import('@vue/test-utils')
+const { createVuetify } = await import('vuetify')
+const { default: Vjsf } = await import('../src/components/vjsf.vue')
+const { sameOptions } = await import('../src/options.js')
+
+const vuetify = createVuetify()
+
+const flush = async () => {
+  for (let i = 0; i < 8; i++) await nextTick()
+  await Promise.resolve()
+}
+
+const schema = { type: 'object', properties: { str1: { type: 'string' }, str2: { type: 'string' } } }
+
+describe('options object identity', () => {
+  it('should not rebuild the state tree when a new but equivalent options object is passed', async () => {
+    const options = { density: 'comfortable', context: { some: 'data' } }
+    const wrapper = mount(Vjsf, {
+      props: { schema, modelValue: { str1: 'a' }, options },
+      global: { plugins: [vuetify] }
+    })
+    await flush()
+
+    const updates = wrapper.emitted('update:state')
+    expect(updates?.length).toBeGreaterThan(0)
+    const statefulLayout = updates[updates.length - 1][0]
+    const stateTree = statefulLayout.stateTree
+
+    // a parent re-render typically produces a new options object with the same content
+    await wrapper.setProps({ options: { density: 'comfortable', context: { some: 'data' } } })
+    await flush()
+    expect(statefulLayout.stateTree).toBe(stateTree)
+
+    // a real change must still be applied
+    await wrapper.setProps({ options: { density: 'compact', context: { some: 'data' } } })
+    await flush()
+    expect(statefulLayout.stateTree).not.toBe(stateTree)
+    expect(statefulLayout.stateTree.root.options.density).toBe('compact')
+  })
+
+  it('should compare functions by reference and plain data deeply in sameOptions', () => {
+    const fn = () => {}
+    expect(sameOptions({ a: 1, b: { c: [1, 2] }, fn }, { a: 1, b: { c: [1, 2] }, fn })).toBe(true)
+    expect(sameOptions({ a: 1 }, { a: 2 })).toBe(false)
+    expect(sameOptions({ fn }, { fn: () => {} })).toBe(false)
+    expect(sameOptions({ a: { b: 1 } }, { a: { b: 1, c: 2 } })).toBe(false)
+    expect(sameOptions({ a: [1, 2] }, { a: [1, 2] })).toBe(true)
+    expect(sameOptions({ a: [1, 2] }, { a: { 0: 1, 1: 2 } })).toBe(false)
+  })
+})


### PR DESCRIPTION
Two compounding causes made every interaction re-render the entire form on large schemas (measured on a real-world 68-element recursive config with rich previews: 1.2–2.7s of blocked main thread per click, halved by this PR, and up to ~4s removed on the consuming app's own remount paths it enabled):

- **Do not update the stateful layout options when equivalent.** On every re-render of the parent, the `fullOptions` computed produced a new but equivalent object (the slots snapshot and the deep-cloned context change identity on each recompute) and the watcher assigned it unconditionally. The root options object's identity is part of every state-node cache key, so the whole state tree lost node identity and the `node.vue` render memo was bypassed tree-wide. The slots object returned by `useSlots()` is now kept by identity (it is stable and mutated in place by vue), and the watcher skips the update when the new options are equivalent (functions compared by reference, plain data deeply).
- **Only provide density defaults on nodes that actually change the density.** Every node wrapped its content in a `v-defaults-provider` whose only role is to propagate `options.density`, and each active provider chains a `mergeDeep` of the whole vuetify defaults on every render. The provider is now `:disabled` (a disabled provider passes the parent defaults through untouched) unless the node's density differs from the density found in the injected vuetify defaults — which also stays correct when the application inserts its own defaults provider between two levels of the form.

Covered by `options-identity.test.js` (equivalent options preserve the state tree identity, real changes still apply) and `density-defaults.test.js` (a single active provider on a shared-density form, override still applies and is scoped).

**Heads-up:** applications that mutated the v-model object in place and relied on the permanent full rebuilds to pick the mutation up will no longer see it — the form only observes changes of identity of its model. One such case existed in data-fair/portals (theme color mode switch) and is fixed there by reassigning the model.
