### PR TITLE
fix: keep the list item menu open when moving an item up or down

### DIFF
--- a/lib/src/components/nodes/list.vue
+++ b/lib/src/components/nodes/list.vue
@@ -154,6 +154,16 @@ const pushEmptyIndexedItem = () => {
 }
 
 /**
+ * follow the item to its new position instead of closing the menu, so that successive moves don't require re-opening it
+ * @param {number} childIndex
+ * @param {number} targetIndex
+ */
+const moveItem = (childIndex, targetIndex) => {
+  props.statefulLayout.input(props.modelValue, moveDataItem(props.modelValue.data, childIndex, targetIndex))
+  menuOpened.value = targetIndex
+}
+
+/**
  * @param {number} childIndex
  */
 const clickDeleteItem = (childIndex) => {
@@ -443,7 +453,7 @@ const toggleDialog = (/** @type {boolean} */value) => {
                     <v-list-item
                       v-if="modelValue.layout.listActions.includes('sort')"
                       :disabled="childIndex === 0"
-                      @click="statefulLayout.input(modelValue, moveDataItem(modelValue.data, childIndex, childIndex - 1)); menuOpened = -1"
+                      @click="moveItem(childIndex, childIndex - 1)"
                     >
                       <template #prepend>
                         <v-icon :icon="options.icons.sortUp" />
@@ -453,7 +463,7 @@ const toggleDialog = (/** @type {boolean} */value) => {
                     <v-list-item
                       v-if="modelValue.layout.listActions.includes('sort')"
                       :disabled="childIndex === modelValue.data.length - 1"
-                      @click="statefulLayout.input(modelValue, moveDataItem(modelValue.data, childIndex, childIndex + 1)); menuOpened = -1"
+                      @click="moveItem(childIndex, childIndex + 1)"
                     >
                       <template #prepend>
                         <v-icon :icon="options.icons.sortDown" />


### PR DESCRIPTION
Moving a list item with **Move up** / **Move down** no longer closes its menu: the menu follows the item to its new position, so successive moves don't require re-opening it each time.

**Why:** having to re-open the menu for every single step made reordering a list tedious.

**Heads-up:** on indexed lists (`patternProperties`) the reorder itself is already a no-op — `producePatchedData` in `@json-layout/core` merges merged-children with `Object.assign`, which preserves the existing key order and discards the reordered one. Since nothing moves, the menu now lands on the neighbouring item instead of closing. That path isn't reachable with defaults (`sort` is not in the default `listActions` for indexed lists) and the real fix belongs in `@json-layout/core`.
