### PR TITLE
fix: add spacing between the error icon and the tab/panel label

### DIFF
--- a/lib/src/components/nodes/expansion-panels.vue
+++ b/lib/src/components/nodes/expansion-panels.vue
@@ -40,8 +40,8 @@ const { compProps } = useNode(toRef(props, 'modelValue'), props.statefulLayout)
       <v-expansion-panel-title>
         <v-icon
           v-if="child.validated && (child.error || child.childError)"
+          start
           color="error"
-          class="mr-2"
           :icon="statefulLayout.options.icons.alert"
         />
         {{ child.layout.title ?? child.layout.label }}

--- a/lib/src/components/nodes/tabs.vue
+++ b/lib/src/components/nodes/tabs.vue
@@ -53,6 +53,7 @@ const tab = ref(0)
       >
         <v-icon
           v-if="child.validated && (child.error || child.childError)"
+          start
           color="error"
           :icon="statefulLayout.options.icons.alert"
         />

--- a/lib/src/components/nodes/vertical-tabs.vue
+++ b/lib/src/components/nodes/vertical-tabs.vue
@@ -54,6 +54,7 @@ const tab = ref(0)
         >
           <v-icon
             v-if="child.validated && (child.error || child.childError)"
+            start
             color="error"
             :icon="statefulLayout.options.icons.alert"
           />


### PR DESCRIPTION
Add the vuetify `start` prop on the alert icon displayed on invalid tabs and expansion panels, so it is no longer stuck against the label.

**Why:** the icon was rendered without any placement prop, leaving no gutter between it and the tab title.

**Heads-up:** expansion panels used `class="mr-2"` for that gutter — switched to `start` too, which uses `margin-inline-end` instead of a physical `margin-right`. Same rendering in LTR, fixed in RTL.
