### PR TITLE
fix: overlay the list item actions instead of reserving a column of width

### DIFF
--- a/lib/src/components/nodes/list.vue
+++ b/lib/src/components/nodes/list.vue
@@ -80,6 +80,13 @@ const zIndex = useZIndexStack(props.modelValue.fullKey)
 const editedItem = computed(() => {
   return props.statefulLayout.activatedItems[props.modelValue.fullKey]
 })
+// activatedItems holds either the index of the item or its key (indexed lists are activated by key)
+const editedItemIndex = computed(() => {
+  if (editedItem.value === undefined) return undefined
+  if (typeof editedItem.value === 'number') return editedItem.value
+  const index = sortableArray.value.findIndex((child) => child.key === editedItem.value)
+  return index === -1 ? undefined : index
+})
 
 const menuOpened = ref(-1)
 const toggleMenu = (/** @type {number} */childIndex, /** @type {boolean} */value) => {
@@ -93,7 +100,7 @@ const activeItem = computed(() => {
     layout.value.listEditMode !== 'inline' &&
     editedItem.value !== undefined
   ) {
-    return editedItem.value
+    return editedItemIndex.value ?? -1
   }
   if (dragging.value !== -1) return -1
   if (menuOpened.value !== -1) return menuOpened.value
@@ -124,6 +131,62 @@ const itemSubtitles = computed(() => {
   if (!expr) return null
   return sortableArray.value.map((child) => props.statefulLayout.evalNodeExpression(props.modelValue, expr, child.data))
 })
+
+/*
+ * the header line of an item carries its title and its close button
+ * the remaining actions are overlaid in the top-right corner and reserve no width,
+ * so the header is rendered as soon as there is anything to put in it, to give
+ * those overlaid actions a line of their own instead of letting them sit on the content
+ */
+const showOverlaidActions = computed(() => {
+  return !options.value.readOnly && menuActions.value.length > 0
+})
+const itemHeaderTitles = computed(() => {
+  return sortableArray.value.map((child, childIndex) => {
+    if (itemTitles.value?.[childIndex]) return itemTitles.value[childIndex]
+    if (layout.value.indexed) return child.key
+    return null
+  })
+})
+const showItemCloseButton = (/** @type {number} */childIndex) => {
+  return !options.value.readOnly &&
+    layout.value.listActions.includes('edit') &&
+    layout.value.listEditMode === 'inline-single' &&
+    editedItemIndex.value === childIndex
+}
+const showItemHeader = (/** @type {number} */childIndex) => {
+  if (itemHeaderTitles.value[childIndex] || itemSubtitles.value?.[childIndex]) return true
+  if (showItemCloseButton(childIndex)) return true
+  return showOverlaidActions.value
+}
+
+/** the nodes rendered in the body of each item, empty when a summary is configured to display nothing */
+const itemsChildren = computed(() => {
+  return sortableArray.value.map((child) => {
+    const nodes = isSection(child) ? child.children : [child]
+    return nodes.filter((node) => node.layout.comp !== 'none')
+  })
+})
+
+/**
+ * the single action displayed in the overlaid actions column of an item, if any
+ * the menu button is rendered even when the item is idle, so that it can be reached with the keyboard,
+ * and only made invisible through the vjsf-list-item-action--idle class
+ * the menu overlay itself is only mounted for the active item, one per idle item would weigh on large lists
+ */
+const itemAppendAction = (/** @type {number} */childIndex) => {
+  // while a drag is in progress the list reorders under the pointer but dragPrepared
+  // keeps pointing at the original index, so all actions are hidden until the drop
+  if (dragging.value !== -1) return null
+  // the close button lives in the header line, not here
+  if (showItemCloseButton(childIndex)) return null
+  if (dragPrepared.value === childIndex) return 'sort'
+  if (editedItem.value === undefined || layout.value.listEditMode === 'menu') return 'menu'
+  return null
+}
+
+/** buttons of the item menus, kept as anchors for the lazily mounted menu overlays */
+const menuButtonRefs = ref(/** @type {any[]} */([]))
 
 const activateOrFocus = (/** @type number | string */childKey) => {
   if (layout.value.listEditMode === 'inline-single' || layout.value.listEditMode === 'dialog') {
@@ -241,7 +304,7 @@ const pasteItem = (child) => {
 }
 
 const itemBorderColor = computed(() => (/** @type {import('@json-layout/core').StateNode} */child, /** @type {number} */childIndex) => {
-  if (editedItem.value === childIndex) return theme.current.value.colors.primary
+  if (editedItemIndex.value === childIndex) return theme.current.value.colors.primary
   if (child.validated && (child.error || child.childError)) return theme.current.value.colors.error
   if (options.value.readOnly) return 'transparent'
   if (activeItem.value === childIndex) return theme.current.value.colors.primary
@@ -277,61 +340,53 @@ const toggleDialog = (/** @type {boolean} */value) => {
           :style="`border: 1px solid ${itemBorderColor(child, childIndex)}`"
           class="vjsf-list-item"
         >
-          <v-list-item-title
-            v-if="itemTitles?.[childIndex]"
-            class="pl-4 pt-2"
+          <div
+            v-if="showItemHeader(childIndex)"
+            class="vjsf-list-item__header"
+            :class="{
+              'vjsf-list-item__header--with-actions': showOverlaidActions && !showItemCloseButton(childIndex),
+              'vjsf-list-item__header--with-close': showItemCloseButton(childIndex),
+              'vjsf-list-item__header--alone': !itemsChildren[childIndex].length
+            }"
           >
-            {{ itemTitles?.[childIndex] }}
-          </v-list-item-title>
-          <v-list-item-title
-            v-else-if="modelValue.layout.indexed"
-            class="pl-4 pt-2"
+            <div class="vjsf-list-item__header-text">
+              <v-list-item-title v-if="itemHeaderTitles[childIndex]">
+                {{ itemHeaderTitles[childIndex] }}
+              </v-list-item-title>
+              <v-list-item-subtitle v-if="itemSubtitles?.[childIndex]">
+                {{ itemSubtitles?.[childIndex] }}
+              </v-list-item-subtitle>
+            </div>
+            <v-spacer />
+            <v-btn
+              v-if="showItemCloseButton(childIndex)"
+              :title="modelValue.messages.close"
+              :icon="options.icons.edit"
+              variant="flat"
+              color="primary"
+              :density="buttonDensity"
+              :disabled="modelValue.loading"
+              @click="statefulLayout.deactivateItem(modelValue)"
+            />
+          </div>
+          <v-row
+            v-if="itemsChildren[childIndex].length"
+            class="pa-3"
           >
-            {{ child.key }}
-          </v-list-item-title>
-          <v-list-item-subtitle
-            v-if="itemSubtitles?.[childIndex]"
-            class="pl-4 pt-2"
-          >
-            {{ itemSubtitles?.[childIndex] }}
-          </v-list-item-subtitle>
-          <v-row class="pa-3">
             <node
-              v-for="grandChild of isSection(child) ? child.children : [child]"
+              v-for="grandChild of itemsChildren[childIndex]"
               :key="grandChild.fullKey"
               :model-value="/** @type import('../../types.js').VjsfNode */(grandChild)"
               :stateful-layout="statefulLayout"
             />
           </v-row>
           <template
-            v-if="!modelValue.options.readOnly && menuActions.length"
+            v-if="showOverlaidActions"
             #append
           >
             <div class="vjsf-list-item-actions-wrapper">
-              <v-list-item-action v-if="activeItem !== childIndex">
-                <v-btn
-                  style="visibility:hidden"
-                  variant="text"
-                  :density="buttonDensity"
-                  :icon="options.icons.edit"
-                  :disabled="modelValue.loading"
-                />
-              </v-list-item-action>
               <v-list-item-action
-                v-else-if="modelValue.layout.listActions.includes('edit') && modelValue.layout.listEditMode === 'inline-single' && editedItem === childIndex"
-              >
-                <v-btn
-                  :title="modelValue.messages.close"
-                  :icon="options.icons.edit"
-                  variant="flat"
-                  color="primary"
-                  :density="buttonDensity"
-                  :disabled="modelValue.loading"
-                  @click="statefulLayout.deactivateItem(modelValue)"
-                />
-              </v-list-item-action>
-              <v-list-item-action
-                v-else-if="dragPrepared === childIndex"
+                v-if="itemAppendAction(childIndex) === 'sort'"
               >
                 <v-btn
                   :title="modelValue.messages.sort"
@@ -344,26 +399,31 @@ const toggleDialog = (/** @type {boolean} */value) => {
                 />
               </v-list-item-action>
               <v-list-item-action
-                v-else-if="(editedItem === undefined || modelValue.layout.listEditMode === 'menu') && menuActions.length"
+                v-else-if="itemAppendAction(childIndex) === 'menu'"
+                :class="{ 'vjsf-list-item-action--idle': activeItem !== childIndex }"
               >
+                <v-btn
+                  :ref="(menuButton) => { menuButtonRefs[childIndex] = menuButton }"
+                  :icon="options.icons.menu"
+                  variant="plain"
+                  slim
+                  :disabled="modelValue.loading"
+                  :density="buttonDensity"
+                  aria-haspopup="menu"
+                  :aria-expanded="menuOpened === childIndex ? 'true' : 'false'"
+                  @click="toggleMenu(childIndex, menuOpened !== childIndex)"
+                />
                 <v-menu
+                  v-if="menuOpened === childIndex || activeItem === childIndex"
                   location="bottom end"
                   :z-index="zIndex"
                   :density="modelValue.options.density"
                   :close-on-content-click="false"
+                  :open-on-click="false"
+                  :activator="menuButtonRefs[childIndex]"
                   :model-value="menuOpened === childIndex"
                   @update:model-value="value => toggleMenu(childIndex, value)"
                 >
-                  <template #activator="{props: activatorProps}">
-                    <v-btn
-                      v-bind="activatorProps"
-                      :icon="options.icons.menu"
-                      variant="plain"
-                      slim
-                      :disabled="modelValue.loading"
-                      :density="buttonDensity"
-                    />
-                  </template>
                   <v-list :density="modelValue.options.density">
                     <template v-if="modelValue.layout.listActions.includes('edit') && modelValue.layout.listEditMode !== 'inline'">
                       <v-menu
@@ -500,7 +560,7 @@ const toggleDialog = (/** @type {boolean} */value) => {
       </template>
       <v-list-item
         v-if="!modelValue.options.readOnly && (modelValue.layout.listActions.includes('add') || modelValue.layout.listActions.includes('paste'))"
-        class="py-2"
+        class="py-2 vjsf-list-add-item"
       >
         <template v-if="modelValue.layout.indexed">
           <v-form
@@ -600,15 +660,93 @@ const toggleDialog = (/** @type {boolean} */value) => {
 </template>
 
 <style>
-.vjsf-list-item .v-list-item__append {
-  height: 100%;
-  align-items: start;
+/*
+ * the actions column is overlaid in the top-right corner of the item instead of
+ * being a column of its own, so that it reserves no width ; nested lists used to
+ * lose 36px of content width per level to it
+ */
+.vjsf-list-item {
+  position: relative;
 }
-.vjsf-list-item .v-list-item__content {
-  padding-right: 4px;
+/* child combinator so that a v-list-item rendered by a custom component in the item body is left alone */
+.vjsf-list-item > .v-list-item__append {
+  position: absolute;
+  top: 0;
+  /* logical property so that the column stays on the end side in rtl, as it was when in flow */
+  inset-inline-end: 0;
+  height: auto;
+  align-items: start;
 }
 .vjsf-list-item-actions-wrapper .v-list-item-action--end {
   margin-inline-start: 0;
   margin-inline-end: 0;
+}
+
+.vjsf-list-item__header {
+  display: flex;
+  align-items: start;
+  gap: 4px;
+  /* the start padding matches the pa-3 of the row below, so that the title aligns with the fields */
+  padding-block: 8px 0;
+  padding-inline: 12px;
+}
+/*
+ * only when actions are overlaid in the corner: the end padding keeps the title clear of them,
+ * and the min-height gives them a line of their own instead of letting them cover the content below
+ */
+.vjsf-list-item__header--with-actions {
+  padding-inline-end: 40px;
+  min-height: var(--vjsf-list-item-header-min-height, 36px);
+}
+/*
+ * the density wrappers carry a variable instead of styling the header through descendant selectors,
+ * so that the closest wrapper wins in nested forms of mixed densities
+ */
+.vjsf-density-default {
+  --vjsf-list-item-header-min-height: 40px;
+}
+.vjsf-density-comfortable {
+  --vjsf-list-item-header-min-height: 36px;
+}
+.vjsf-density-compact {
+  --vjsf-list-item-header-min-height: 32px;
+}
+/* the close button occupies the corner itself, nothing to reserve */
+.vjsf-list-item__header--with-close {
+  padding-inline-end: 4px;
+}
+/* when the header is the whole item it fills its content box, so that its text is vertically centered */
+.vjsf-list-item__header--alone {
+  align-items: center;
+  padding-block: 0;
+}
+.vjsf-list-item__header-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+/* a long item title wraps instead of being truncated by the vuetify defaults */
+.vjsf-list-item__header-text .v-list-item-title,
+.vjsf-list-item__header-text .v-list-item-subtitle {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+/*
+ * an idle item keeps its menu button rendered, so that it stays reachable with the keyboard,
+ * but invisible and not clickable until the item is hovered, focused or otherwise active
+ */
+.vjsf-list-item-action--idle {
+  opacity: 0;
+  pointer-events: none;
+}
+.vjsf-list-item:focus-within .vjsf-list-item-action--idle {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* v-list-item__content clips its overflow and the add button sits flush against it, cutting off its elevation shadow */
+.vjsf-list-add-item > .v-list-item__content {
+  overflow: visible;
 }
 </style>

--- a/lib/src/composables/use-dnd.js
+++ b/lib/src/composables/use-dnd.js
@@ -22,8 +22,6 @@ export default function useDnd (array, callback) {
   const draggable = ref(-1)
   const dragging = ref(-1)
 
-  hovered.value = 1
-
   const itemBind = (/** @type {number} */itemIndex, /** @type {Record<String, any>} */defaultItemProps) => ({
     ...defaultItemProps,
     // hover the item


### PR DESCRIPTION
## Problem

The actions column of list items (the ⋮ menu, the sort handle, the close button of `inline-single` edition) was a real column of the `v-list-item`, so every list lost 36px of content width to it — and nested lists lost 36px per nesting level. It also mounted a full `VMenu`/`VOverlay` per item, even idle ones, which weighed on large lists.

## Changes

- The actions are now overlaid in the top-right corner of the item (`position: absolute` on the append slot, logical `inset-inline-end` for RTL) and reserve no width.
- A header line (`vjsf-list-item__header`) carries the item title/subtitle and the close button of `inline-single` edition, and reserves the corner (40px end padding + min-height) **only when actions can actually be rendered** — a readOnly list with item titles keeps its full width.
- The ⋮ menu button is always rendered so it stays reachable with the keyboard (revealed through `:focus-within`), but the `VMenu` overlay itself is only mounted for the active item, anchored on the button through `:activator`. Idle items no longer mount any overlay machinery.
- The header min-height per density goes through a CSS variable set on the `.vjsf-density-*` wrappers, so the **closest** wrapper wins in nested forms of mixed densities (descendant selectors let the last stylesheet rule win instead).
- The activated item of indexed lists (activated by key, a string) is normalized to an index (`editedItemIndex`), so the close button and the border highlight now work for them in `inline-single` mode.
- All actions are hidden while a drag is in progress, as before the refactor — the list reorders live under the pointer while `dragPrepared` keeps pointing at the original index, so the sort handle would show on the wrong item.
- The append CSS rule uses a child combinator so a `v-list-item` rendered by a custom component inside an item body is left alone.
- Removed a leftover debug line in `use-dnd.js` (`hovered.value = 1`) that made item 1 appear hovered on mount.

## Verification

- `vue-tsc` and eslint pass, the 24 vitest tests pass (both TZ runs).
- Manually tested on the doc pages (`/lists/lists`, `/lists/indexed-lists`, `/lists/edit-mode`): menu opens with mouse and keyboard (Enter), Escape closes and returns focus to the button with correct `aria-expanded`, clicking the button while open closes without re-opening, `inline-single` close button in the header, `menu` mode side edition menu, and sort drag (no ghost handle during the drag, correct reorder on drop). Zero `.v-menu` nodes in the DOM at rest, no console errors.
