### PR TITLE
fix: no tab, panel or step for a child hidden by a "if" expression

### DIFF
--- a/lib/src/components/nodes/expansion-panels.vue
+++ b/lib/src/components/nodes/expansion-panels.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, toRef } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import { VExpansionPanels, VExpansionPanel, VExpansionPanelTitle, VExpansionPanelText } from 'vuetify/components/VExpansionPanel'
 import { VContainer, VRow } from 'vuetify/components/VGrid'
 import { VIcon } from 'vuetify/components/VIcon'
@@ -8,6 +8,7 @@ import Node from '../node.vue'
 import SectionHeader from '../fragments/section-header.vue'
 import ChildSubtitle from '../fragments/child-subtitle.vue'
 import useNode from '../../composables/use-node.js'
+import { useVisibleChildren } from '../../composables/use-visible-children.js'
 import { useDefaults } from 'vuetify'
 
 useDefaults({}, 'VjsfExpansionPanels')
@@ -27,19 +28,39 @@ const props = defineProps({
 
 const { compProps } = useNode(toRef(props, 'modelValue'), props.statefulLayout)
 
-// a child hidden by a "if" expression is kept in the state tree as a "none" node,
-// it must not get a panel of its own
-const visibleChildren = computed(() => props.modelValue.children.filter(child => child.layout.comp !== 'none'))
+const panelsProps = computed(() => {
+  const panelsProps = { ...compProps.value }
+  // the open panels are managed locally, a modelValue in layout.props is only an initial value
+  delete panelsProps.modelValue
+  return panelsProps
+})
+
+const visibleChildren = useVisibleChildren(() => props.modelValue.children)
+
+const openPanels = ref(compProps.value.modelValue)
+watch(visibleChildren, (children) => {
+  const isVisible = (/** @type {unknown} */index) => children.some(visible => visible.index === index)
+  if (Array.isArray(openPanels.value)) {
+    // with the "multiple" prop several panels are open at once, forget the ones that became hidden
+    if (!openPanels.value.every(isVisible)) openPanels.value = openPanels.value.filter(isVisible)
+  } else if (openPanels.value !== undefined && !isVisible(openPanels.value)) {
+    // the open panel became hidden, the "mandatory" prop promises that one stays open
+    openPanels.value = compProps.value.mandatory ? children[0]?.index : undefined
+  }
+})
 
 </script>
 
 <template>
   <section-header :node="modelValue" />
-  <v-expansion-panels v-bind="compProps">
+  <v-expansion-panels
+    v-model="openPanels"
+    v-bind="panelsProps"
+  >
     <v-expansion-panel
-      v-for="child of visibleChildren"
+      v-for="{ child, index } of visibleChildren"
       :key="child.key"
-      :value="child.key"
+      :value="index"
     >
       <v-expansion-panel-title>
         <v-icon

--- a/lib/src/components/nodes/expansion-panels.vue
+++ b/lib/src/components/nodes/expansion-panels.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { toRef } from 'vue'
+import { computed, toRef } from 'vue'
 import { VExpansionPanels, VExpansionPanel, VExpansionPanelTitle, VExpansionPanelText } from 'vuetify/components/VExpansionPanel'
 import { VContainer, VRow } from 'vuetify/components/VGrid'
 import { VIcon } from 'vuetify/components/VIcon'
@@ -27,15 +27,19 @@ const props = defineProps({
 
 const { compProps } = useNode(toRef(props, 'modelValue'), props.statefulLayout)
 
+// a child hidden by a "if" expression is kept in the state tree as a "none" node,
+// it must not get a panel of its own
+const visibleChildren = computed(() => props.modelValue.children.filter(child => child.layout.comp !== 'none'))
+
 </script>
 
 <template>
   <section-header :node="modelValue" />
   <v-expansion-panels v-bind="compProps">
     <v-expansion-panel
-      v-for="(child, i) of modelValue.children"
+      v-for="child of visibleChildren"
       :key="child.key"
-      :value="i"
+      :value="child.key"
     >
       <v-expansion-panel-title>
         <v-icon

--- a/lib/src/components/nodes/stepper.vue
+++ b/lib/src/components/nodes/stepper.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { VStepper, VStepperHeader, VStepperItem, VStepperWindow, VStepperWindowItem, VStepperActions } from 'vuetify/components/VStepper'
 import { VContainer, VRow, VSpacer } from 'vuetify/components/VGrid'
 import { VBtn } from 'vuetify/components/VBtn'
@@ -9,6 +9,7 @@ import Node from '../node.vue'
 import SectionHeader from '../fragments/section-header.vue'
 import ChildSubtitle from '../fragments/child-subtitle.vue'
 import { useDefaults } from 'vuetify'
+import { useVisibleChildren, useActiveChildIndex } from '../../composables/use-visible-children.js'
 
 useDefaults({}, 'VjsfStepper')
 
@@ -26,10 +27,17 @@ const props = defineProps({
 })
 
 const nodeProps = computed(() => {
-  return props.modelValue.props
+  const nodeProps = { ...props.modelValue.props }
+  // the current step is managed locally, a modelValue in layout.props is only an initial value
+  delete nodeProps.modelValue
+  return nodeProps
 })
 
-const step = ref(0)
+const visibleChildren = useVisibleChildren(() => props.modelValue.children)
+const step = useActiveChildIndex(visibleChildren, props.modelValue.props?.modelValue)
+
+const previousStep = computed(() => visibleChildren.value.filter(({ index }) => index < /** @type {number} */(step.value)).pop()?.index)
+const nextStep = computed(() => visibleChildren.value.find(({ index }) => index > /** @type {number} */(step.value))?.index)
 
 const firstErrorIndex = computed(() => {
   const index = props.modelValue.children.findIndex(child => child.validated && !!(child.error || child.childError))
@@ -37,9 +45,9 @@ const firstErrorIndex = computed(() => {
 })
 
 const goNext = () => {
-  const child = props.modelValue.children[step.value]
+  const child = props.modelValue.children[/** @type {number} */(step.value)]
   props.statefulLayout.validateNodeRecurse(child)
-  if (!(child.error || child.childError)) step.value++
+  if (!(child.error || child.childError)) step.value = nextStep.value
 }
 </script>
 
@@ -51,23 +59,24 @@ const goNext = () => {
   >
     <v-stepper-header>
       <template
-        v-for="(child, i) of modelValue.children"
+        v-for="{ child, index } of visibleChildren"
         :key="child.key"
       >
         <v-stepper-item
-          :value="i"
+          :value="index"
           :title="/** @type {string | undefined} */(child.layout.title ?? child.layout.label)"
           :error="child.validated && !!(child.error || child.childError)"
           :complete="child.validated && !(child.error || child.childError)"
-          :editable="i <= firstErrorIndex"
+          :editable="index <= firstErrorIndex"
         />
         <v-divider />
       </template>
     </v-stepper-header>
     <v-stepper-window>
       <v-stepper-window-item
-        v-for="(child) of modelValue.children"
+        v-for="{ child, index } of visibleChildren"
         :key="child.key"
+        :value="index"
       >
         <v-container
           fluid
@@ -88,9 +97,9 @@ const goNext = () => {
     <v-stepper-actions>
       <template #prev>
         <v-btn
-          v-if="step > 0"
+          v-if="previousStep !== undefined"
           variant="text"
-          @click="step--"
+          @click="step = previousStep"
         >
           Back
         </v-btn>
@@ -98,7 +107,7 @@ const goNext = () => {
       <template #next>
         <v-spacer />
         <v-btn
-          v-if="step < modelValue.children.length - 1"
+          v-if="nextStep !== undefined"
           variant="flat"
           color="primary"
           @click="goNext"

--- a/lib/src/components/nodes/tabs.vue
+++ b/lib/src/components/nodes/tabs.vue
@@ -5,12 +5,13 @@ import { VIcon } from 'vuetify/components/VIcon'
 import { VSheet } from 'vuetify/components/VSheet'
 import { VWindow, VWindowItem } from 'vuetify/components/VWindow'
 import { useDefaults } from 'vuetify'
-import { ref, computed, watch } from 'vue'
+import { computed } from 'vue'
 import { isSection } from '@json-layout/core/state'
 import Node from '../node.vue'
 import SectionHeader from '../fragments/section-header.vue'
 import ChildSubtitle from '../fragments/child-subtitle.vue'
 import useCompDefaults from '../../composables/use-comp-defaults.js'
+import { useVisibleChildren, useActiveChildIndex } from '../../composables/use-visible-children.js'
 
 useDefaults({}, 'VjsfTabs')
 const vSheetProps = useCompDefaults('VjsfTabs-VSheet', { border: true })
@@ -29,21 +30,18 @@ const { modelValue, statefulLayout } = defineProps({
 })
 
 const nodeProps = computed(() => {
-  return {
+  /** @type {Record<string, any>} */
+  const nodeProps = {
     ...modelValue.props,
     direction: /** @type {'horizontal'} */ ('horizontal')
   }
+  // the selected tab is managed locally, a modelValue in layout.props is only an initial value
+  delete nodeProps.modelValue
+  return nodeProps
 })
 
-// a child hidden by a "if" expression is kept in the state tree as a "none" node,
-// it must not get a tab of its own in the tabs bar
-const visibleChildren = computed(() => modelValue.children.filter(child => child.layout.comp !== 'none'))
-
-const tab = ref(visibleChildren.value[0]?.key)
-watch(visibleChildren, (children) => {
-  // the active tab can become hidden, fallback on the first remaining one
-  if (!children.some(child => child.key === tab.value)) tab.value = children[0]?.key
-})
+const visibleChildren = useVisibleChildren(() => modelValue.children)
+const tab = useActiveChildIndex(visibleChildren, modelValue.props?.modelValue)
 </script>
 
 <template>
@@ -54,9 +52,9 @@ watch(visibleChildren, (children) => {
       v-bind="nodeProps"
     >
       <v-tab
-        v-for="child of visibleChildren"
+        v-for="{ child, index } of visibleChildren"
         :key="child.key"
-        :value="child.key"
+        :value="index"
         :color="child.validated && (child.error || child.childError) ? 'error' : undefined"
       >
         <v-icon
@@ -70,9 +68,9 @@ watch(visibleChildren, (children) => {
     </v-tabs>
     <v-window v-model="tab">
       <v-window-item
-        v-for="child of visibleChildren"
+        v-for="{ child, index } of visibleChildren"
         :key="child.key"
-        :value="child.key"
+        :value="index"
       >
         <v-container fluid>
           <child-subtitle :model-value="child" />

--- a/lib/src/components/nodes/tabs.vue
+++ b/lib/src/components/nodes/tabs.vue
@@ -5,7 +5,7 @@ import { VIcon } from 'vuetify/components/VIcon'
 import { VSheet } from 'vuetify/components/VSheet'
 import { VWindow, VWindowItem } from 'vuetify/components/VWindow'
 import { useDefaults } from 'vuetify'
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { isSection } from '@json-layout/core/state'
 import Node from '../node.vue'
 import SectionHeader from '../fragments/section-header.vue'
@@ -35,7 +35,15 @@ const nodeProps = computed(() => {
   }
 })
 
-const tab = ref(0)
+// a child hidden by a "if" expression is kept in the state tree as a "none" node,
+// it must not get a tab of its own in the tabs bar
+const visibleChildren = computed(() => modelValue.children.filter(child => child.layout.comp !== 'none'))
+
+const tab = ref(visibleChildren.value[0]?.key)
+watch(visibleChildren, (children) => {
+  // the active tab can become hidden, fallback on the first remaining one
+  if (!children.some(child => child.key === tab.value)) tab.value = children[0]?.key
+})
 </script>
 
 <template>
@@ -46,9 +54,9 @@ const tab = ref(0)
       v-bind="nodeProps"
     >
       <v-tab
-        v-for="(child, i) of modelValue.children"
+        v-for="child of visibleChildren"
         :key="child.key"
-        :value="i"
+        :value="child.key"
         :color="child.validated && (child.error || child.childError) ? 'error' : undefined"
       >
         <v-icon
@@ -62,9 +70,9 @@ const tab = ref(0)
     </v-tabs>
     <v-window v-model="tab">
       <v-window-item
-        v-for="(child, i) of modelValue.children"
+        v-for="child of visibleChildren"
         :key="child.key"
-        :value="i"
+        :value="child.key"
       >
         <v-container fluid>
           <child-subtitle :model-value="child" />

--- a/lib/src/components/nodes/vertical-tabs.vue
+++ b/lib/src/components/nodes/vertical-tabs.vue
@@ -5,12 +5,13 @@ import { VContainer, VRow } from 'vuetify/components/VGrid'
 import { VIcon } from 'vuetify/components/VIcon'
 import { VSheet } from 'vuetify/components/VSheet'
 import { VWindow, VWindowItem } from 'vuetify/components/VWindow'
-import { ref, computed, watch } from 'vue'
+import { computed } from 'vue'
 import Node from '../node.vue'
 import SectionHeader from '../fragments/section-header.vue'
 import ChildSubtitle from '../fragments/child-subtitle.vue'
 import { useDefaults } from 'vuetify'
 import useCompDefaults from '../../composables/use-comp-defaults.js'
+import { useVisibleChildren, useActiveChildIndex } from '../../composables/use-visible-children.js'
 
 useDefaults({}, 'VjsfVerticalTabs')
 const vSheetProps = useCompDefaults('VjsfVerticalTabs-VSheet', { border: true })
@@ -29,21 +30,18 @@ const { modelValue, statefulLayout } = defineProps({
 })
 
 const nodeProps = computed(() => {
-  return {
+  /** @type {Record<string, any>} */
+  const nodeProps = {
     ...modelValue.props,
     direction: /** @type {'vertical'} */ ('vertical')
   }
+  // the selected tab is managed locally, a modelValue in layout.props is only an initial value
+  delete nodeProps.modelValue
+  return nodeProps
 })
 
-// a child hidden by a "if" expression is kept in the state tree as a "none" node,
-// it must not get a tab of its own in the tabs bar
-const visibleChildren = computed(() => modelValue.children.filter(child => child.layout.comp !== 'none'))
-
-const tab = ref(visibleChildren.value[0]?.key)
-watch(visibleChildren, (children) => {
-  // the active tab can become hidden, fallback on the first remaining one
-  if (!children.some(child => child.key === tab.value)) tab.value = children[0]?.key
-})
+const visibleChildren = useVisibleChildren(() => modelValue.children)
+const tab = useActiveChildIndex(visibleChildren, modelValue.props?.modelValue)
 </script>
 
 <template>
@@ -55,9 +53,9 @@ watch(visibleChildren, (children) => {
         v-bind="nodeProps"
       >
         <v-tab
-          v-for="child of visibleChildren"
+          v-for="{ child, index } of visibleChildren"
           :key="child.key"
-          :value="child.key"
+          :value="index"
           :color="child.validated && (child.error || child.childError) ? 'error' : undefined"
         >
           <v-icon
@@ -74,9 +72,9 @@ watch(visibleChildren, (children) => {
         class="flex-fill"
       >
         <v-window-item
-          v-for="child of visibleChildren"
+          v-for="{ child, index } of visibleChildren"
           :key="child.key"
-          :value="child.key"
+          :value="index"
         >
           <v-container fluid>
             <child-subtitle :model-value="child" />

--- a/lib/src/components/nodes/vertical-tabs.vue
+++ b/lib/src/components/nodes/vertical-tabs.vue
@@ -5,7 +5,7 @@ import { VContainer, VRow } from 'vuetify/components/VGrid'
 import { VIcon } from 'vuetify/components/VIcon'
 import { VSheet } from 'vuetify/components/VSheet'
 import { VWindow, VWindowItem } from 'vuetify/components/VWindow'
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import Node from '../node.vue'
 import SectionHeader from '../fragments/section-header.vue'
 import ChildSubtitle from '../fragments/child-subtitle.vue'
@@ -35,7 +35,15 @@ const nodeProps = computed(() => {
   }
 })
 
-const tab = ref(0)
+// a child hidden by a "if" expression is kept in the state tree as a "none" node,
+// it must not get a tab of its own in the tabs bar
+const visibleChildren = computed(() => modelValue.children.filter(child => child.layout.comp !== 'none'))
+
+const tab = ref(visibleChildren.value[0]?.key)
+watch(visibleChildren, (children) => {
+  // the active tab can become hidden, fallback on the first remaining one
+  if (!children.some(child => child.key === tab.value)) tab.value = children[0]?.key
+})
 </script>
 
 <template>
@@ -47,9 +55,9 @@ const tab = ref(0)
         v-bind="nodeProps"
       >
         <v-tab
-          v-for="(child, i) of modelValue.children"
+          v-for="child of visibleChildren"
           :key="child.key"
-          :value="i"
+          :value="child.key"
           :color="child.validated && (child.error || child.childError) ? 'error' : undefined"
         >
           <v-icon
@@ -66,9 +74,9 @@ const tab = ref(0)
         class="flex-fill"
       >
         <v-window-item
-          v-for="(child, i) of modelValue.children"
+          v-for="child of visibleChildren"
           :key="child.key"
-          :value="i"
+          :value="child.key"
         >
           <v-container fluid>
             <child-subtitle :model-value="child" />

--- a/lib/src/composables/use-visible-children.js
+++ b/lib/src/composables/use-visible-children.js
@@ -1,0 +1,39 @@
+import { computed, ref, watch } from 'vue'
+
+/**
+ * A child hidden by a "if" expression is kept in the state tree as a "none" node, so are the
+ * children with an explicit "none" layout. The containers that render one header per child
+ * (tabs, vertical-tabs, expansion-panels, stepper) must skip them, otherwise the section takes
+ * an empty clickable slot in the header.
+ *
+ * The index in the full children array is kept alongside the child: hidden children keep their
+ * slot in the state tree so these indexes are stable, and they are the values a schema uses to
+ * preselect a section through layout.props.modelValue.
+ *
+ * @template {{layout: {comp: string}}} T
+ * @param {() => readonly T[]} getChildren
+ * @returns {import('vue').ComputedRef<{child: T, index: number}[]>}
+ */
+export function useVisibleChildren (getChildren) {
+  return computed(() => getChildren()
+    .map((child, index) => ({ child, index }))
+    .filter(({ child }) => child.layout.comp !== 'none'))
+}
+
+/**
+ * Track the index of the selected child of a container, and fallback on the first visible one
+ * when the selected child becomes hidden (the header would show no selection at all, while the
+ * window would keep displaying a section).
+ *
+ * @param {import('vue').ComputedRef<{index: number}[]>} visibleChildren
+ * @param {unknown} initialIndex the index preselected by layout.props.modelValue, if any
+ * @returns {import('vue').Ref<number | undefined>}
+ */
+export function useActiveChildIndex (visibleChildren, initialIndex) {
+  const isVisible = (/** @type {unknown} */index) => visibleChildren.value.some(visible => visible.index === index)
+  const activeIndex = ref(isVisible(initialIndex) ? /** @type {number} */(initialIndex) : visibleChildren.value[0]?.index)
+  watch(visibleChildren, (children) => {
+    if (!children.some(visible => visible.index === activeIndex.value)) activeIndex.value = children[0]?.index
+  })
+  return activeIndex
+}

--- a/lib/test/hidden-children.test.js
+++ b/lib/test/hidden-children.test.js
@@ -45,9 +45,9 @@ async function mountForm (schema, initialData = {}) {
 
 // a section hidden by a layout "if" expression is kept in the state tree as a "none"
 // node, the containers that render one header per child have to skip it
-const schema = (comp) => ({
+const schema = (layout) => ({
   type: 'object',
-  layout: comp,
+  layout,
   allOf: [
     {
       title: 'Section 1',
@@ -68,13 +68,16 @@ const schema = (comp) => ({
   }
 })
 
+const titles = (wrapper, selector) => wrapper.findAll(selector).map(item => item.text())
+const stepperBtn = (wrapper, label) => wrapper.findAll('.v-stepper-actions .v-btn').find(btn => btn.text() === label)
+
 describe('containers with a header per child', () => {
   it('should not render a tab for a section hidden by a "if" expression', async () => {
     const shown = await mountForm(schema('tabs'), { showSection2: true })
-    expect(shown.findAll('.v-tab').map(t => t.text())).toEqual(['Section 1', 'Section 2', 'Section 3'])
+    expect(titles(shown, '.v-tab')).toEqual(['Section 1', 'Section 2', 'Section 3'])
 
     const hidden = await mountForm(schema('tabs'), { showSection2: false })
-    expect(hidden.findAll('.v-tab').map(t => t.text())).toEqual(['Section 1', 'Section 3'])
+    expect(titles(hidden, '.v-tab')).toEqual(['Section 1', 'Section 3'])
   })
 
   it('should select another tab when the active one becomes hidden', async () => {
@@ -83,17 +86,87 @@ describe('containers with a header per child', () => {
     expect(wrapper.find('.v-tab--selected').text()).toBe('Section 2')
 
     await wrapper.updateData({ showSection2: false })
-    expect(wrapper.findAll('.v-tab').map(t => t.text())).toEqual(['Section 1', 'Section 3'])
+    expect(titles(wrapper, '.v-tab')).toEqual(['Section 1', 'Section 3'])
     expect(wrapper.find('.v-tab--selected').text()).toBe('Section 1')
   })
 
   it('should not render a vertical tab for a section hidden by a "if" expression', async () => {
     const hidden = await mountForm(schema('vertical-tabs'), { showSection2: false })
-    expect(hidden.findAll('.v-tab').map(t => t.text())).toEqual(['Section 1', 'Section 3'])
+    expect(titles(hidden, '.v-tab')).toEqual(['Section 1', 'Section 3'])
   })
 
   it('should not render an expansion panel for a section hidden by a "if" expression', async () => {
     const hidden = await mountForm(schema('expansion-panels'), { showSection2: false })
-    expect(hidden.findAll('.v-expansion-panel-title').map(t => t.text())).toEqual(['Section 1', 'Section 3'])
+    expect(titles(hidden, '.v-expansion-panel-title')).toEqual(['Section 1', 'Section 3'])
+  })
+
+  it('should not render a step for a section hidden by a "if" expression', async () => {
+    const hidden = await mountForm(schema('stepper'), { showSection2: false })
+    expect(titles(hidden, '.v-stepper-item')).toEqual(['Section 1', 'Section 3'])
+  })
+})
+
+// the value of a tab/panel/step is the index of the child in the full children array, hidden
+// children keep their slot in the state tree so these indexes are stable and a schema can use
+// them to preselect a section
+describe('containers preselecting a child through layout.props', () => {
+  it('should open the tab designated by layout.props.modelValue', async () => {
+    const wrapper = await mountForm(schema({ comp: 'tabs', props: { modelValue: 1 } }), { showSection2: true })
+    expect(wrapper.find('.v-tab--selected').text()).toBe('Section 2')
+    // the tab bar and the window agree, and the selection is still interactive
+    expect(wrapper.find('.v-window-item--active').text()).toContain('str2')
+    await wrapper.findAll('.v-tab')[2].trigger('click')
+    expect(wrapper.find('.v-tab--selected').text()).toBe('Section 3')
+  })
+
+  it('should ignore a layout.props.modelValue designating a hidden section', async () => {
+    const wrapper = await mountForm(schema({ comp: 'tabs', props: { modelValue: 1 } }), { showSection2: false })
+    expect(wrapper.find('.v-tab--selected').text()).toBe('Section 1')
+  })
+
+  it('should open the expansion panel designated by layout.props.modelValue', async () => {
+    const wrapper = await mountForm(schema({ comp: 'expansion-panels', props: { modelValue: 1 } }), { showSection2: true })
+    expect(titles(wrapper, '.v-expansion-panel--active')).toEqual(['Section 2str2str2'])
+    // the panels stay interactive, the preselection is only an initial value
+    await wrapper.findAll('.v-expansion-panel-title')[2].trigger('click')
+    expect(titles(wrapper, '.v-expansion-panel--active')).toEqual(['Section 3str3str3'])
+  })
+})
+
+describe('expansion panels with a hidden open panel', () => {
+  it('should open another panel when "mandatory" is set', async () => {
+    const layout = { comp: 'expansion-panels', props: { mandatory: true, modelValue: 1 } }
+    const wrapper = await mountForm(schema(layout), { showSection2: true })
+    expect(titles(wrapper, '.v-expansion-panel--active')).toEqual(['Section 2str2str2'])
+
+    await wrapper.updateData({ showSection2: false })
+    expect(titles(wrapper, '.v-expansion-panel--active')).toEqual(['Section 1str1str1'])
+  })
+
+  it('should simply close it when "mandatory" is not set', async () => {
+    const wrapper = await mountForm(schema({ comp: 'expansion-panels', props: { modelValue: 1 } }), { showSection2: true })
+    await wrapper.updateData({ showSection2: false })
+    expect(titles(wrapper, '.v-expansion-panel--active')).toEqual([])
+  })
+})
+
+describe('stepper navigation around hidden steps', () => {
+  it('should skip a hidden step when going forward', async () => {
+    const wrapper = await mountForm(schema('stepper'), { showSection2: false })
+    expect(wrapper.find('.v-stepper-item--selected').text()).toBe('Section 1')
+
+    await stepperBtn(wrapper, 'Next').trigger('click')
+    expect(wrapper.find('.v-stepper-item--selected').text()).toBe('Section 3')
+    // Section 3 is the last visible step, there is nothing left to go to
+    expect(stepperBtn(wrapper, 'Next')).toBeUndefined()
+  })
+
+  it('should skip a hidden step when going backward', async () => {
+    const wrapper = await mountForm(schema('stepper'), { showSection2: false })
+    await stepperBtn(wrapper, 'Next').trigger('click')
+    expect(wrapper.find('.v-stepper-item--selected').text()).toBe('Section 3')
+
+    await stepperBtn(wrapper, 'Back').trigger('click')
+    expect(wrapper.find('.v-stepper-item--selected').text()).toBe('Section 1')
   })
 })

--- a/lib/test/hidden-children.test.js
+++ b/lib/test/hidden-children.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick, shallowRef } from 'vue'
+import { createVuetify } from 'vuetify'
+import { compile, StatefulLayout } from '@json-layout/core'
+import Tree from '../src/components/tree.vue'
+import { nodeComponents } from '../src/components/nodes/index.js'
+import { defaultIcons } from '../src/options.js'
+
+const vuetify = createVuetify()
+
+async function mountForm (schema, initialData = {}) {
+  const compiledLayout = compile(schema)
+  const statefulLayout = new StatefulLayout(
+    compiledLayout,
+    compiledLayout.skeletonTrees[compiledLayout.mainTree],
+    {
+      debounceInputMs: 0,
+      width: 1000,
+      density: 'comfortable',
+      nodeComponents,
+      icons: defaultIcons,
+      onData: () => {},
+      onUpdate: () => {},
+      onAutofocus: () => {}
+    },
+    initialData
+  )
+  const stateTree = shallowRef(statefulLayout.stateTree)
+  const wrapper = mount(Tree, {
+    props: { modelValue: stateTree.value, statefulLayout },
+    global: { plugins: [vuetify] }
+  })
+  await nextTick()
+  await nextTick()
+  wrapper.updateData = async (data) => {
+    statefulLayout.data = data
+    stateTree.value = statefulLayout.stateTree
+    await wrapper.setProps({ modelValue: stateTree.value })
+    await nextTick()
+    await nextTick()
+  }
+  return wrapper
+}
+
+// a section hidden by a layout "if" expression is kept in the state tree as a "none"
+// node, the containers that render one header per child have to skip it
+const schema = (comp) => ({
+  type: 'object',
+  layout: comp,
+  allOf: [
+    {
+      title: 'Section 1',
+      properties: { str1: { type: 'string' } }
+    },
+    {
+      title: 'Section 2',
+      layout: { if: 'rootData.showSection2' },
+      properties: { str2: { type: 'string' } }
+    },
+    {
+      title: 'Section 3',
+      properties: { str3: { type: 'string' } }
+    }
+  ],
+  properties: {
+    showSection2: { type: 'boolean', layout: 'none' }
+  }
+})
+
+describe('containers with a header per child', () => {
+  it('should not render a tab for a section hidden by a "if" expression', async () => {
+    const shown = await mountForm(schema('tabs'), { showSection2: true })
+    expect(shown.findAll('.v-tab').map(t => t.text())).toEqual(['Section 1', 'Section 2', 'Section 3'])
+
+    const hidden = await mountForm(schema('tabs'), { showSection2: false })
+    expect(hidden.findAll('.v-tab').map(t => t.text())).toEqual(['Section 1', 'Section 3'])
+  })
+
+  it('should select another tab when the active one becomes hidden', async () => {
+    const wrapper = await mountForm(schema('tabs'), { showSection2: true })
+    await wrapper.findAll('.v-tab')[1].trigger('click')
+    expect(wrapper.find('.v-tab--selected').text()).toBe('Section 2')
+
+    await wrapper.updateData({ showSection2: false })
+    expect(wrapper.findAll('.v-tab').map(t => t.text())).toEqual(['Section 1', 'Section 3'])
+    expect(wrapper.find('.v-tab--selected').text()).toBe('Section 1')
+  })
+
+  it('should not render a vertical tab for a section hidden by a "if" expression', async () => {
+    const hidden = await mountForm(schema('vertical-tabs'), { showSection2: false })
+    expect(hidden.findAll('.v-tab').map(t => t.text())).toEqual(['Section 1', 'Section 3'])
+  })
+
+  it('should not render an expansion panel for a section hidden by a "if" expression', async () => {
+    const hidden = await mountForm(schema('expansion-panels'), { showSection2: false })
+    expect(hidden.findAll('.v-expansion-panel-title').map(t => t.text())).toEqual(['Section 1', 'Section 3'])
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -2797,9 +2797,9 @@
       "license": "MIT"
     },
     "node_modules/@json-layout/core": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@json-layout/core/-/core-2.8.1.tgz",
-      "integrity": "sha512-pOn7MaCmDGdvkN+j8FyjIiot1L1Rjx/zc7x6HkgiaJj/nxHsP10kdE4d0BgE60/H9FwgMxsFaRf34s0CzixIMg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@json-layout/core/-/core-2.8.2.tgz",
+      "integrity": "sha512-se1UBOEo1u3qnpERhD0J7oEbphlD7PYQ5u+maRw7EkoyOChlStvnSJWS2av76CLsxXxW5nh2VaY2Lats1qHwYg==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",


### PR DESCRIPTION
Four containers build one header per child — `tabs`, `vertical-tabs`, `expansion-panels` and `stepper` — and all four looped over `modelValue.children` unfiltered. A child hidden by a `layout.if` expression is kept in the state tree as a `none` node (so is any child with an explicit `none` layout), so a hidden section took an empty, clickable slot in the header. `node-content.vue` already skipped these nodes, the containers did not.
The filtering now lives in a `use-visible-children` composable shared by the four. It keeps the index of the child in the full children array as the value of the header: hidden children keep their slot in the state tree, so these indexes are stable and a schema can still preselect a section with `layout.props.modelValue`.
That preselection is now the initial value of the local selection instead of being spread over the `v-model`. The two used to fight each other: the tabs bar was pinned by the static prop while the window followed the local ref, and the tabs were no longer clickable.
The stepper needed two more fixes: its window items relied on their registration order for their value while the stepper items used the child index, and `Back`/`Next` moved the index by one, landing on a hidden step. The expansion panels are controlled locally for the same reason, which also gives them the fallback the tabs already had: when the open panel becomes hidden, `mandatory` opens the first remaining one, `multiple` simply forgets the hidden indexes.

**Why:** reported on a processing config schema whose last tab is gated by `layout: { if: "rootData.mode !== 'validate'" }` — hiding it left an empty 90px tab after the visible ones.

**Heads-up:** `expansion-panels` goes from an internal state to a local `v-model`, which is the real regression risk of the lot — a test covers opening a panel by clicking its title. The header values are unchanged, they are still the child indexes.

**Unrelated commit:** the lock bump for `@json-layout/core@2.8.2`. `npm ci` was failing on `master` since it was published; only the resolution of that one package is touched, regenerating the lock with npm also rewrites the root package name after the checkout directory and flips a batch of unrelated `dev`/`devOptional` flags.
